### PR TITLE
[javascript] Switch Package Manager from yarn to pnpm

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -11,14 +11,14 @@ on:
       - '.github/workflows/jest.yml'
       - './node-version'
       - 'javascript/package.json'
-      - 'javascript/yarn.lock'
+      - 'javascript/pnpm-lock.yaml'
       - 'javascript/**/*.js'
   pull_request:
     paths:
       - '.github/workflows/jest.yml'
       - './node-version'
       - 'javascript/package.json'
-      - 'javascript/yarn.lock'
+      - 'javascript/pnpm-lock.yaml'
       - 'javascript/**/*.js'
 
 permissions:

--- a/javascript/pnpm-workspace.yaml
+++ b/javascript/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+ignoredBuiltDependencies:
+  - core-js


### PR DESCRIPTION
## Summary

Replace yarn.lock with pnpm-lock.yaml as triggers of GHA CI because they manage configuration of the application ecosystem.