### PR TITLE
[ruby] Replace #size with #length to Prevent Unexpected Behaviour in the Case of Integer

### DIFF
--- a/ruby/calculator_cli_app/src/application.rb
+++ b/ruby/calculator_cli_app/src/application.rb
@@ -6,7 +6,7 @@ module CalculatorCliApp
     include ::Validations::ArgsValidation
 
     def initialize(args)
-      @args_size = args.size
+      @args_size = args.length
       @seed      = args.first
       @n         = args.last
     end


### PR DESCRIPTION
## Summary

When the receiver is one of Array, Hash or String, there is basically no difference in terms of return value which represents the number of elements.
However, if it's of Integer, it returns the number of bytes in the machine representation of self; the value is system-dependent.
It may cause unexpected behaviours, so it should be replaced with #length because `Integer#length` raises `NoMethodError`.

Ref. https://docs.ruby-lang.org/en/master/Integer.html#method-i-size