### PR TITLE
[ruby] Resolve Violations Reported by Rubocop

### DIFF
--- a/ruby/Steepfile
+++ b/ruby/Steepfile
@@ -1,15 +1,15 @@
 D = Steep::Diagnostic
 
 target :app do
-  check "calculator_cli_app"
-  check "fibonacci_sequence"
-  check "fizzbuzz"
-  check "letter_inspection"
-  check "nabeatsu"
-  signature "sig"
+  check 'calculator_cli_app'
+  check 'fibonacci_sequence'
+  check 'fizzbuzz'
+  check 'letter_inspection'
+  check 'nabeatsu'
+  signature 'sig'
 
-  library "json"
-  library "net-http"
+  library 'json'
+  library 'net-http'
 
   configure_code_diagnostics(D::Ruby.default)
 end


### PR DESCRIPTION
```bash
Inspecting 20 files
.C..................

Offenses:

Steepfile:4:9: C: [Corrected] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  check "calculator_cli_app"
        ^^^^^^^^^^^^^^^^^^^^
Steepfile:5:9: C: [Corrected] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  check "fibonacci_sequence"
        ^^^^^^^^^^^^^^^^^^^^
Steepfile:6:9: C: [Corrected] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  check "fizzbuzz"
        ^^^^^^^^^^
Steepfile:7:9: C: [Corrected] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  check "letter_inspection"
        ^^^^^^^^^^^^^^^^^^^
Steepfile:8:9: C: [Corrected] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  check "nabeatsu"
        ^^^^^^^^^^
Steepfile:9:13: C: [Corrected] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  signature "sig"
            ^^^^^
Steepfile:11:11: C: [Corrected] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  library "json"
          ^^^^^^
Steepfile:12:11: C: [Corrected] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  library "net-http"
          ^^^^^^^^^^

20 files inspected, 8 offenses detected, 8 offenses corrected
```