### PR TITLE
[ruby] Resolve Violation against Convention reported by Rubocop

### DIFF
--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rake/testtask'
 task default: :test
 


### PR DESCRIPTION
```bash
Run bundle exec rubocop
Inspecting 6 files
.C....

Offenses:

Rakefile:1:1: C: [Correctable] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
require 'rake/testtask'
^

6 files inspected, 1 offense detected, 1 offense autocorrectable
Error: Process completed with exit code 1.
```