### PR TITLE
[python] Rename Label to pytest on Github Actions

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -75,7 +75,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-python
-      - name: UnitTest
+      - name: pytest
         working-directory: ./python
         run: bash run_unittests.sh
   # mypy:


### PR DESCRIPTION
## Summary

On GitHub Actions workflow configuration, the job executing `pytest` is named `UnitTest` as it used to be.  
It is confusing a bit so should be amended.