### PR TITLE
[python] Execute Lint Fixes

### DIFF
--- a/python/calculator_cli_app/main.py
+++ b/python/calculator_cli_app/main.py
@@ -1,15 +1,15 @@
+from application import Application
 import sys
 import os
 import shutil
 import glob
 sys.path.append('./calculator_cli_app/src')
-from application import Application
 
 sys.argv.pop(0)
-app = Application(args = sys.argv)
+app = Application(args=sys.argv)
 app.run()
 
-pycaches = glob.glob(os.path.join('.', '**', '__pycache__'), recursive = True)
+pycaches = glob.glob(os.path.join('.', '**', '__pycache__'), recursive=True)
 for pycache in pycaches:
     if os.path.exists(pycache):
         shutil.rmtree(pycache)

--- a/python/calculator_cli_app/src/application.py
+++ b/python/calculator_cli_app/src/application.py
@@ -1,21 +1,22 @@
+from args_validation import __validate__
+from calculation_query import CalculationQuery
+from data_type_conversion import __to_int_with_rescue__
 import sys
 sys.path.append('./calculator_cli_app/src')
 sys.path.append('./calculator_cli_app/src/lib')
 sys.path.append('./calculator_cli_app/src/queries')
 sys.path.append('./calculator_cli_app/src/validations')
-from data_type_conversion import __to_int_with_rescue__
-from calculation_query import CalculationQuery
-from args_validation import __validate__
+
 
 class Application:
     def __init__(self, args):
         self.args_size = len(args)
         if self.args_size > 0:
             self.seed = args[0]
-            self.n    = args[-1]
+            self.n = args[-1]
         else:
             self.seed = ''
-            self.n    = ''
+            self.n = ''
         self.calculation_query = CalculationQuery(self.seed)
 
     def run(self):

--- a/python/calculator_cli_app/src/queries/calculation_query.py
+++ b/python/calculator_cli_app/src/queries/calculation_query.py
@@ -2,10 +2,11 @@ import urllib.request
 import os
 import json
 
+
 class CalculationQuery:
     def __init__(self, seed):
         self.seed = seed
-        self.uri  = os.environ['CALCULATION_API']
+        self.uri = os.environ['CALCULATION_API']
 
     def f(self, n):
         if n == 0:
@@ -13,15 +14,17 @@ class CalculationQuery:
         elif n == 2:
             return 2
         elif n % 2 == 0:
-            return self.f(n - 1) + self.f(n - 2) + self.f(n - 3) + self.f(n - 4)
+            return self.f(n - 1) + self.f(n - 2) + \
+                self.f(n - 3) + self.f(n - 4)
         else:
             return self.__ask_server__(n)
 
   # private
 
     def __ask_server__(self, n):
-        params = { 'seed': self.seed, 'n': n }
-        req    = urllib.request.Request('{}?{}'.format(self.uri, urllib.parse.urlencode(params)))
-        res    = urllib.request.urlopen(req)
+        params = {'seed': self.seed, 'n': n}
+        req = urllib.request.Request('{}?{}'.format(
+            self.uri, urllib.parse.urlencode(params)))
+        res = urllib.request.urlopen(req)
         result = json.loads(res.read())['result']
         return result

--- a/python/calculator_cli_app/src/validations/args_validation.py
+++ b/python/calculator_cli_app/src/validations/args_validation.py
@@ -8,6 +8,6 @@ def __validate__(args_size, seed, n):
     elif args_size == 1:
         print('Provide both seed and n')
         exit(1)
-    elif type(seed) != str or n == 'Not Integer':
+    elif not isinstance(seed, str) or n == 'Not Integer':
         print('Provide seed as string and n as number')
         exit(1)

--- a/python/calculator_cli_app/test/queries/test_calculation_query.py
+++ b/python/calculator_cli_app/test/queries/test_calculation_query.py
@@ -1,4 +1,3 @@
-from calculation_query import CalculationQuery
 import unittest
 import sys
 from io import StringIO
@@ -6,6 +5,7 @@ import glob
 import os
 import shutil
 sys.path.append('./src/queries')
+from calculation_query import CalculationQuery
 
 
 class TestCalculationQuery(unittest.TestCase):

--- a/python/calculator_cli_app/test/queries/test_calculation_query.py
+++ b/python/calculator_cli_app/test/queries/test_calculation_query.py
@@ -1,3 +1,4 @@
+from calculation_query import CalculationQuery
 import unittest
 import sys
 from io import StringIO
@@ -5,14 +6,19 @@ import glob
 import os
 import shutil
 sys.path.append('./src/queries')
-from calculation_query import CalculationQuery
+
 
 class TestCalculationQuery(unittest.TestCase):
     def setUp(self):
         self.calculation_query = CalculationQuery('foo')
-        self.org_stdout        = sys.stdout
-        sys.stdout             = StringIO()
-        self.pycaches          = glob.glob(os.path.join('.', '**', '__pycache__'), recursive = True)
+        self.org_stdout = sys.stdout
+        sys.stdout = StringIO()
+        self.pycaches = glob.glob(
+            os.path.join(
+                '.',
+                '**',
+                '__pycache__'),
+            recursive=True)
 
     def tearDown(self):
         sys.stdout = self.org_stdout
@@ -20,17 +26,21 @@ class TestCalculationQuery(unittest.TestCase):
             if os.path.exists(pycache):
                 shutil.rmtree(pycache)
 
+
 class TestArgumentZero(TestCalculationQuery):
     def test_f_with_zero(self):
         self.assertEqual(self.calculation_query.f(0), 1)
+
 
 class TestArgumentTwo(TestCalculationQuery):
     def test_f_with_two(self):
         self.assertEqual(self.calculation_query.f(2), 2)
 
+
 class TestArgumentFour(TestCalculationQuery):
     def test_f_with_four(self):
         self.assertEqual(self.calculation_query.f(4), 348)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/calculator_cli_app/test/test_application.py
+++ b/python/calculator_cli_app/test/test_application.py
@@ -1,4 +1,3 @@
-from application import Application
 import unittest
 import sys
 from io import StringIO
@@ -9,6 +8,7 @@ sys.path.append('./src')
 sys.path.append('./src/lib')
 sys.path.append('./src/queries')
 sys.path.append('./src/validations')
+from application import Application
 
 
 class TestApplication(unittest.TestCase):

--- a/python/calculator_cli_app/test/test_application.py
+++ b/python/calculator_cli_app/test/test_application.py
@@ -1,3 +1,4 @@
+from application import Application
 import unittest
 import sys
 from io import StringIO
@@ -8,15 +9,20 @@ sys.path.append('./src')
 sys.path.append('./src/lib')
 sys.path.append('./src/queries')
 sys.path.append('./src/validations')
-from application import Application
+
 
 class TestApplication(unittest.TestCase):
     def setUp(self):
         self.org_stdout = sys.stdout
-        sys.stdout      = StringIO()
-        argv            = ['foo', 4]
-        self.app        = Application(args = argv)
-        self.pycaches   = glob.glob(os.path.join('.', '**', '__pycache__'), recursive = True)
+        sys.stdout = StringIO()
+        argv = ['foo', 4]
+        self.app = Application(args=argv)
+        self.pycaches = glob.glob(
+            os.path.join(
+                '.',
+                '**',
+                '__pycache__'),
+            recursive=True)
 
     def test_run_success(self):
         self.app.run()
@@ -27,6 +33,7 @@ class TestApplication(unittest.TestCase):
         for pycache in self.pycaches:
             if os.path.exists(pycache):
                 shutil.rmtree(pycache)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/fibonacci_sequence/main.py
+++ b/python/fibonacci_sequence/main.py
@@ -1,13 +1,13 @@
+from fibonacci import *
 import sys
 import os
 import shutil
 import glob
 sys.path.append('./fibonacci/src')
-from fibonacci import *
 
 print(fibonacci(0, 20))
 
-pycaches = glob.glob(os.path.join('.', '**', '__pycache__'), recursive = True)
+pycaches = glob.glob(os.path.join('.', '**', '__pycache__'), recursive=True)
 for pycache in pycaches:
     if os.path.exists(pycache):
         shutil.rmtree(pycache)

--- a/python/fibonacci_sequence/src/fibonacci.py
+++ b/python/fibonacci_sequence/src/fibonacci.py
@@ -1,7 +1,7 @@
 def fibonacci(init_num, iter):
     current_num = init_num
-    next_num    = current_num + 1
-    result      = list()
+    next_num = current_num + 1
+    result = list()
     for num in range(init_num, iter + init_num):
         result.append(current_num)
         current_num, next_num = next_num, current_num + next_num

--- a/python/fibonacci_sequence/test/test_fibonacci.py
+++ b/python/fibonacci_sequence/test/test_fibonacci.py
@@ -1,19 +1,26 @@
+from fibonacci import *
 import unittest
 import sys
 import glob
 import os
 import shutil
 sys.path.append('./src')
-from fibonacci import *
+
 
 class TestFibonacci(unittest.TestCase):
     def setUp(self):
-        self.pycaches = glob.glob(os.path.join('.', '**', '__pycache__'), recursive = True)
+        self.pycaches = glob.glob(
+            os.path.join(
+                '.',
+                '**',
+                '__pycache__'),
+            recursive=True)
 
     def tearDown(self):
         for pycache in self.pycaches:
             if os.path.exists(pycache):
                 shutil.rmtree(pycache)
+
 
 class TestCase1(TestFibonacci):
     def test_fibonacci(self):
@@ -22,12 +29,14 @@ class TestCase1(TestFibonacci):
             [0, 1, 1, 2, 3, 5, 8, 13, 21, 34]
         )
 
+
 class TestCase2(TestFibonacci):
     def test_fibonacci(self):
         self.assertEqual(
             fibonacci(10, 10),
             [10, 11, 21, 32, 53, 85, 138, 223, 361, 584]
         )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/fibonacci_sequence/test/test_fibonacci.py
+++ b/python/fibonacci_sequence/test/test_fibonacci.py
@@ -1,10 +1,10 @@
-from fibonacci import *
 import unittest
 import sys
 import glob
 import os
 import shutil
 sys.path.append('./src')
+from fibonacci import *
 
 
 class TestFibonacci(unittest.TestCase):

--- a/python/fizzbuzz/main.py
+++ b/python/fizzbuzz/main.py
@@ -1,9 +1,9 @@
+from fizzbuzz import *
 import sys
 import os
 import shutil
 import glob
 sys.path.append('./fizzbuzz/src')
-from fizzbuzz import *
 
 result_1 = list()
 result_2 = list()
@@ -17,7 +17,7 @@ for i in range(1, 101):
 print(result_1)
 print(result_2)
 
-pycaches = glob.glob(os.path.join('.', '**', '__pycache__'), recursive = True)
+pycaches = glob.glob(os.path.join('.', '**', '__pycache__'), recursive=True)
 for pycache in pycaches:
     if os.path.exists(pycache):
         shutil.rmtree(pycache)

--- a/python/fizzbuzz/src/fizzbuzz.py
+++ b/python/fizzbuzz/src/fizzbuzz.py
@@ -9,6 +9,8 @@ def fizzbuzz_in_if(num):
         result = str(num)
     return result
 
+
 def fizzbuzz_in_ternary(num):
-    result = 'FizzBuzz' if num % 3 == 0 and num % 5 == 0 else 'Fizz' if num % 3 == 0 else 'Buzz' if num % 5 == 0 else str(num)
+    result = 'FizzBuzz' if num % 3 == 0 and num % 5 == 0 else 'Fizz' if num % 3 == 0 else 'Buzz' if num % 5 == 0 else str(
+        num)
     return result

--- a/python/fizzbuzz/test/test_fizzbuzz.py
+++ b/python/fizzbuzz/test/test_fizzbuzz.py
@@ -1,10 +1,10 @@
-from fizzbuzz import *
 import unittest
 import sys
 import glob
 import os
 import shutil
 sys.path.append('./src')
+from fizzbuzz import *
 
 
 class TestFizzBuzz(unittest.TestCase):

--- a/python/fizzbuzz/test/test_fizzbuzz.py
+++ b/python/fizzbuzz/test/test_fizzbuzz.py
@@ -1,19 +1,26 @@
+from fizzbuzz import *
 import unittest
 import sys
 import glob
 import os
 import shutil
 sys.path.append('./src')
-from fizzbuzz import *
+
 
 class TestFizzBuzz(unittest.TestCase):
     def setUp(self):
-        self.pycaches = glob.glob(os.path.join('.', '**', '__pycache__'), recursive = True)
+        self.pycaches = glob.glob(
+            os.path.join(
+                '.',
+                '**',
+                '__pycache__'),
+            recursive=True)
 
     def tearDown(self):
         for pycache in self.pycaches:
             if os.path.exists(pycache):
                 shutil.rmtree(pycache)
+
 
 class TestIfStatement(TestFizzBuzz):
     def test_fizzbuzz(self):
@@ -27,6 +34,7 @@ class TestIfStatement(TestFizzBuzz):
             else:
                 self.assertEqual(fizzbuzz_in_if(num), str(num))
 
+
 class TestTernaryStatement(TestFizzBuzz):
     def test_fizzbuzz(self):
         for num in range(1, 101):
@@ -38,6 +46,7 @@ class TestTernaryStatement(TestFizzBuzz):
                 self.assertEqual(fizzbuzz_in_ternary(num), 'Buzz')
             else:
                 self.assertEqual(fizzbuzz_in_ternary(num), str(num))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/letter_inspection/main.py
+++ b/python/letter_inspection/main.py
@@ -1,23 +1,23 @@
+from application import Application
 import sys
 import os
 import shutil
 import glob
 sys.path.append('./letter_inspection/src')
-from application import Application
 
-str_1     = 'hogefoobar'
-str_2     = 'abefghooor'
-str_3     = 'hoge'
-str_4     = 'piyopoopee'
-pattern_1 = Application(str_1 = str_1, str_2 = str_2)
-pattern_2 = Application(str_1 = str_1, str_2 = str_3)
-pattern_3 = Application(str_1 = str_1, str_2 = str_4)
+str_1 = 'hogefoobar'
+str_2 = 'abefghooor'
+str_3 = 'hoge'
+str_4 = 'piyopoopee'
+pattern_1 = Application(str_1=str_1, str_2=str_2)
+pattern_2 = Application(str_1=str_1, str_2=str_3)
+pattern_3 = Application(str_1=str_1, str_2=str_4)
 
 print(pattern_1.exactly_equal_size_and_included())
 print(pattern_2.exactly_equal_size_and_included())
 print(pattern_3.exactly_equal_size_and_included())
 
-pycaches = glob.glob(os.path.join('.', '**', '__pycache__'), recursive = True)
+pycaches = glob.glob(os.path.join('.', '**', '__pycache__'), recursive=True)
 for pycache in pycaches:
     if os.path.exists(pycache):
         shutil.rmtree(pycache)

--- a/python/letter_inspection/src/application.py
+++ b/python/letter_inspection/src/application.py
@@ -4,7 +4,9 @@ class Application:
         self.str_2 = str_2
 
     def exactly_equal_size_and_included(self):
-        return self.__sort_string__(self.str_1) == self.__sort_string__(self.str_2)
+        return self.__sort_string__(
+            self.str_1) == self.__sort_string__(
+            self.str_2)
 
     # private
 

--- a/python/letter_inspection/test/test_application.py
+++ b/python/letter_inspection/test/test_application.py
@@ -1,10 +1,10 @@
-from application import Application
 import unittest
 import sys
 import glob
 import os
 import shutil
 sys.path.append('./src')
+from application import Application
 
 
 class TestApplication(unittest.TestCase):

--- a/python/letter_inspection/test/test_application.py
+++ b/python/letter_inspection/test/test_application.py
@@ -1,41 +1,52 @@
+from application import Application
 import unittest
 import sys
 import glob
 import os
 import shutil
 sys.path.append('./src')
-from application import Application
+
 
 class TestApplication(unittest.TestCase):
     def setUp(self):
-        str_1          = 'hogefoobar'
-        str_2          = 'abefghooor'
-        str_3          = 'hoge'
-        str_4          = 'piyopoopee'
-        self.pattern_1 = Application(str_1 = str_1, str_2 = str_2)
-        self.pattern_2 = Application(str_1 = str_1, str_2 = str_3)
-        self.pattern_3 = Application(str_1 = str_1, str_2 = str_4)
-        self.pycaches  = glob.glob(os.path.join('.', '**', '__pycache__'), recursive = True)
+        str_1 = 'hogefoobar'
+        str_2 = 'abefghooor'
+        str_3 = 'hoge'
+        str_4 = 'piyopoopee'
+        self.pattern_1 = Application(str_1=str_1, str_2=str_2)
+        self.pattern_2 = Application(str_1=str_1, str_2=str_3)
+        self.pattern_3 = Application(str_1=str_1, str_2=str_4)
+        self.pycaches = glob.glob(
+            os.path.join(
+                '.',
+                '**',
+                '__pycache__'),
+            recursive=True)
 
     def tearDown(self):
         for pycache in self.pycaches:
             if os.path.exists(pycache):
                 shutil.rmtree(pycache)
 
+
 class TestRegularCase(TestApplication):
     def test_exactly_equal_size_and_included_1(self):
         self.assertTrue(self.pattern_1.exactly_equal_size_and_included())
 
+
 class TestIrregularCase(TestApplication):
     pass
+
 
 class TestCase1(TestIrregularCase):
     def test_exactly_equal_size_and_included_2(self):
         self.assertFalse(self.pattern_2.exactly_equal_size_and_included())
 
+
 class TestCase1(TestIrregularCase):
     def test_exactly_equal_size_and_included_3(self):
         self.assertFalse(self.pattern_3.exactly_equal_size_and_included())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/nabeatsu/main.py
+++ b/python/nabeatsu/main.py
@@ -1,9 +1,9 @@
+from nabeatsu import *
 import sys
 import os
 import shutil
 import glob
 sys.path.append('./nabeatsu/src')
-from nabeatsu import *
 
 result_1 = list()
 result_2 = list()
@@ -17,7 +17,7 @@ for i in range(1, 41):
 print(result_1)
 print(result_2)
 
-pycaches = glob.glob(os.path.join('.', '**', '__pycache__'), recursive = True)
+pycaches = glob.glob(os.path.join('.', '**', '__pycache__'), recursive=True)
 for pycache in pycaches:
     if os.path.exists(pycache):
         shutil.rmtree(pycache)

--- a/python/nabeatsu/src/nabeatsu.py
+++ b/python/nabeatsu/src/nabeatsu.py
@@ -6,6 +6,7 @@ def go_crazy_in_if(num):
         result = str(num)
     return result
 
+
 def go_crazy_in_ternary(num):
     # Express the status of 'crazy' with '!'
     result = str(num) + '!' if num % 3 == 0 or '3' in str(num) else str(num)

--- a/python/nabeatsu/test/test_nabeatsu.py
+++ b/python/nabeatsu/test/test_nabeatsu.py
@@ -1,10 +1,10 @@
-from nabeatsu import *
 import unittest
 import sys
 import glob
 import os
 import shutil
 sys.path.append('./src')
+from nabeatsu import *
 
 
 class TestNabeatsu(unittest.TestCase):

--- a/python/nabeatsu/test/test_nabeatsu.py
+++ b/python/nabeatsu/test/test_nabeatsu.py
@@ -1,19 +1,26 @@
+from nabeatsu import *
 import unittest
 import sys
 import glob
 import os
 import shutil
 sys.path.append('./src')
-from nabeatsu import *
+
 
 class TestNabeatsu(unittest.TestCase):
     def setUp(self):
-        self.pycaches = glob.glob(os.path.join('.', '**', '__pycache__'), recursive = True)
+        self.pycaches = glob.glob(
+            os.path.join(
+                '.',
+                '**',
+                '__pycache__'),
+            recursive=True)
 
     def tearDown(self):
         for pycache in self.pycaches:
             if os.path.exists(pycache):
                 shutil.rmtree(pycache)
+
 
 class TestIfStatement(TestNabeatsu):
     def test_go_crazy(self):
@@ -23,6 +30,7 @@ class TestIfStatement(TestNabeatsu):
             else:
                 self.assertEqual(go_crazy_in_if(num), str(num))
 
+
 class TestTernaryStatement(TestNabeatsu):
     def test_go_crazy(self):
         for num in range(1, 41):
@@ -30,6 +38,7 @@ class TestTernaryStatement(TestNabeatsu):
                 self.assertEqual(go_crazy_in_ternary(num), str(num) + '!')
             else:
                 self.assertEqual(go_crazy_in_ternary(num), str(num))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/requirements.lock
+++ b/python/requirements.lock
@@ -1,8 +1,11 @@
+ast_serialize==0.3.0
+autoflake8==0.4.1
+autopep8==2.3.2
 flake8==7.3.0
 iniconfig==2.3.0
-librt==0.9.0
+librt==0.10.0
 mccabe==0.7.0
-mypy==1.20.2
+mypy==2.0.0
 mypy_extensions==1.1.0
 packaging==26.2
 pathspec==1.1.1

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,5 @@
+autoflake8==0.4.1
+autopep8==2.3.2
 flake8==7.3.0
-mypy==1.20.2
+mypy==2.0.0
 pytest==9.0.3


### PR DESCRIPTION
## 1. Overview

This project makes use of [flake8](https://pypi.org/project/flake8/) as an inspector of violations against Python syntax and convention.
However, it does not fix them, so some other libraries need installing, which are [autoflake8](https://pypi.org/project/autoflake8/) and [autopep8](https://pypi.org/project/autopep8/)

## 2. Commit

- [Install lint-fix library and update dependencies](https://github.com/hayat01sh1da/coding-tests/commit/3edefc0b9067ada8b09c743c0a68c3f49eab35e6)
- [Execute lint fixed with autopep8](https://github.com/hayat01sh1da/coding-tests/commit/fb7a39452e983b9652557f7de6db29f04a153a6d)
- [Move module imports to the top of the file in order to comply with PEP 8 guidelines](https://github.com/hayat01sh1da/coding-tests/pull/72/changes/9221da9b4dacd9c80583d855f3320e0418f7d1d4)