### PR TITLE
[python] Install Type Checking

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -78,14 +78,18 @@ jobs:
       - name: pytest
         working-directory: ./python
         run: bash run_unittests.sh
-  # mypy:
-  #   timeout-minutes: 10
-  #   runs-on: ubuntu-latest
-  #   needs: change-detection
-  #   if: needs.change-detection.outputs.python-changes == 'true'
-  #   steps:
-  #     - uses: actions/checkout@v6
-  #     - uses: ./.github/actions/setup-python
-  #     - name: mypy
-  #       working-directory: ./python
-  #       run: mypy .
+  mypy:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    needs: change-detection
+    if: needs.change-detection.outputs.python-changes == 'true'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-python
+      - name: mypy
+        working-directory: ./python
+        # `mypy .` cannot be used here: the five sibling sub-projects each
+        # have top-level `main.py`/`test/conftest.py`, which mypy reports as
+        # "Duplicate module" when checked together. run_mypy.sh type-checks
+        # each sub-project independently (mirrors run_unittests.sh).
+        run: bash run_mypy.sh

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -77,7 +77,16 @@ jobs:
       - uses: ./.github/actions/setup-python
       - name: pytest
         working-directory: ./python
-        run: bash run_unittests.sh
+        run: |
+          status=0
+          for directory in $(ls -d */)
+          do
+            cd $directory
+            pytest . || status=1
+            cd ../
+          done
+          exit "${status}"
+
   mypy:
     timeout-minutes: 10
     runs-on: ubuntu-latest
@@ -88,8 +97,12 @@ jobs:
       - uses: ./.github/actions/setup-python
       - name: mypy
         working-directory: ./python
-        # `mypy .` cannot be used here: the five sibling sub-projects each
-        # have top-level `main.py`/`test/conftest.py`, which mypy reports as
-        # "Duplicate module" when checked together. run_mypy.sh type-checks
-        # each sub-project independently (mirrors run_unittests.sh).
-        run: bash run_mypy.sh
+        run: |
+          status=0
+          for directory in $(ls -d */)
+          do
+            cd $directory
+            mypy . || status=1
+            cd ../
+          done
+          exit "${status}"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -76,6 +76,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-python
       - name: pytest
+        env:
+          CALCULATION_API: ${{ vars.CALCULATION_API }}
         working-directory: ./python
         run: |
           status=0

--- a/python/calculator_cli_app/pyproject.toml
+++ b/python/calculator_cli_app/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.mypy]
+python_version = "3.14"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true

--- a/python/calculator_cli_app/src/application.py
+++ b/python/calculator_cli_app/src/application.py
@@ -1,6 +1,7 @@
 from args_validation import __validate__
 from calculation_query import CalculationQuery
 from data_type_conversion import __to_int_with_rescue__
+from typing import cast
 import sys
 sys.path.append('./calculator_cli_app/src')
 sys.path.append('./calculator_cli_app/src/lib')
@@ -9,18 +10,19 @@ sys.path.append('./calculator_cli_app/src/validations')
 
 
 class Application:
-    def __init__(self, args):
-        self.args_size = len(args)
+    def __init__(self, args: list[str]) -> None:
+        self.args_size: int = len(args)
         if self.args_size > 0:
-            self.seed = args[0]
-            self.n = args[-1]
+            self.seed: str = args[0]
+            self.n: str = args[-1]
         else:
             self.seed = ''
             self.n = ''
-        self.calculation_query = CalculationQuery(self.seed)
+        self.calculation_query: CalculationQuery = CalculationQuery(self.seed)
 
-    def run(self):
+    def run(self) -> None:
         __validate__(self.args_size, self.seed, __to_int_with_rescue__(self.n))
 
-        result = self.calculation_query.f(__to_int_with_rescue__(self.n))
+        result = self.calculation_query.f(
+            cast(int, __to_int_with_rescue__(self.n)))
         print(result)

--- a/python/calculator_cli_app/src/lib/data_type_conversion.py
+++ b/python/calculator_cli_app/src/lib/data_type_conversion.py
@@ -1,4 +1,4 @@
-def __to_int_with_rescue__(n):
+def __to_int_with_rescue__(n: str) -> int | str:
     try:
         return int(n)
     except ValueError:

--- a/python/calculator_cli_app/src/queries/calculation_query.py
+++ b/python/calculator_cli_app/src/queries/calculation_query.py
@@ -1,14 +1,15 @@
 import urllib.request
+import urllib.parse
 import os
 import json
 
 
 class CalculationQuery:
-    def __init__(self, seed):
-        self.seed = seed
-        self.uri = os.environ['CALCULATION_API']
+    def __init__(self, seed: str) -> None:
+        self.seed: str = seed
+        self.uri: str = os.environ['CALCULATION_API']
 
-    def f(self, n):
+    def f(self, n: int) -> int:
         if n == 0:
             return 1
         elif n == 2:
@@ -19,12 +20,12 @@ class CalculationQuery:
         else:
             return self.__ask_server__(n)
 
-  # private
+    # private
 
-    def __ask_server__(self, n):
+    def __ask_server__(self, n: int) -> int:
         params = {'seed': self.seed, 'n': n}
         req = urllib.request.Request('{}?{}'.format(
             self.uri, urllib.parse.urlencode(params)))
         res = urllib.request.urlopen(req)
-        result = json.loads(res.read())['result']
+        result: int = json.loads(res.read())['result']
         return result

--- a/python/calculator_cli_app/src/validations/args_validation.py
+++ b/python/calculator_cli_app/src/validations/args_validation.py
@@ -1,4 +1,4 @@
-def __validate__(args_size, seed, n):
+def __validate__(args_size: int, seed: str, n: int | str) -> None:
     if args_size > 2:
         print('Too many arguments')
         exit(1)

--- a/python/calculator_cli_app/test/conftest.py
+++ b/python/calculator_cli_app/test/conftest.py
@@ -1,7 +1,9 @@
+import pytest
 import glob
 import os
 import shutil
 import sys
+from collections.abc import Iterator
 
 sys.path.append('./src')
 sys.path.append('./src/lib')
@@ -9,12 +11,15 @@ sys.path.append('./src/queries')
 sys.path.append('./src/validations')
 
 
-import pytest
-
-
 @pytest.fixture(autouse=True)
-def _cleanup_pycaches():
-    before = set(glob.glob(os.path.join('.', '**', '__pycache__'), recursive=True))
+def __cleanup_caches__() -> Iterator[None]:
+    before = set(
+        glob.glob(
+            os.path.join(
+                '.',
+                '**',
+                '__pycache__'),
+            recursive=True))
     yield
     for pycache in before:
         if os.path.exists(pycache):

--- a/python/calculator_cli_app/test/conftest.py
+++ b/python/calculator_cli_app/test/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-import glob
+import re
 import os
 import shutil
 import sys
@@ -13,14 +13,10 @@ sys.path.append('./src/validations')
 
 @pytest.fixture(autouse=True)
 def __cleanup_caches__() -> Iterator[None]:
-    before = set(
-        glob.glob(
-            os.path.join(
-                '.',
-                '**',
-                '__pycache__'),
-            recursive=True))
     yield
-    for pycache in before:
-        if os.path.exists(pycache):
-            shutil.rmtree(pycache)
+    cache_dir = re.compile(r'^(?:__pycache__|\.pytest_cache|\.mypy_cache)$')
+    for root, dirs, _ in os.walk('.'):
+        for name in list(dirs):
+            if cache_dir.match(name):
+                shutil.rmtree(os.path.join(root, name), ignore_errors=True)
+                dirs.remove(name)

--- a/python/calculator_cli_app/test/queries/test_calculation_query.py
+++ b/python/calculator_cli_app/test/queries/test_calculation_query.py
@@ -11,5 +11,5 @@ from calculation_query import CalculationQuery
         (4, 348),
     ],
 )
-def test_f(argument, expected):
+def test_f(argument: int, expected: int) -> None:
     assert CalculationQuery('foo').f(argument) == expected

--- a/python/calculator_cli_app/test/test_application.py
+++ b/python/calculator_cli_app/test/test_application.py
@@ -1,7 +1,9 @@
+import pytest
+
 from application import Application
 
 
-def test_run_success(capsys):
-    Application(args=['foo', 4]).run()
+def test_run_success(capsys: pytest.CaptureFixture[str]) -> None:
+    Application(args=['foo', '4']).run()
     captured = capsys.readouterr()
     assert captured.out == '348\n'

--- a/python/fibonacci_sequence/main.py
+++ b/python/fibonacci_sequence/main.py
@@ -1,4 +1,4 @@
-from fibonacci import *
+from fibonacci import fibonacci
 import sys
 import os
 import shutil

--- a/python/fibonacci_sequence/pyproject.toml
+++ b/python/fibonacci_sequence/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.mypy]
+python_version = "3.14"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true

--- a/python/fibonacci_sequence/src/fibonacci.py
+++ b/python/fibonacci_sequence/src/fibonacci.py
@@ -1,4 +1,4 @@
-def fibonacci(init_num, iter):
+def fibonacci(init_num: int, iter: int) -> list[int]:
     current_num = init_num
     next_num = current_num + 1
     result = list()

--- a/python/fibonacci_sequence/test/conftest.py
+++ b/python/fibonacci_sequence/test/conftest.py
@@ -1,17 +1,22 @@
+import pytest
 import glob
 import os
 import shutil
 import sys
+from collections.abc import Iterator
 
 sys.path.append('./src')
 
 
-import pytest
-
-
 @pytest.fixture(autouse=True)
-def _cleanup_pycaches():
-    before = set(glob.glob(os.path.join('.', '**', '__pycache__'), recursive=True))
+def __cleanup_caches__() -> Iterator[None]:
+    before = set(
+        glob.glob(
+            os.path.join(
+                '.',
+                '**',
+                '__pycache__'),
+            recursive=True))
     yield
     for pycache in before:
         if os.path.exists(pycache):

--- a/python/fibonacci_sequence/test/conftest.py
+++ b/python/fibonacci_sequence/test/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-import glob
+import re
 import os
 import shutil
 import sys
@@ -10,14 +10,10 @@ sys.path.append('./src')
 
 @pytest.fixture(autouse=True)
 def __cleanup_caches__() -> Iterator[None]:
-    before = set(
-        glob.glob(
-            os.path.join(
-                '.',
-                '**',
-                '__pycache__'),
-            recursive=True))
     yield
-    for pycache in before:
-        if os.path.exists(pycache):
-            shutil.rmtree(pycache)
+    cache_dir = re.compile(r'^(?:__pycache__|\.pytest_cache|\.mypy_cache)$')
+    for root, dirs, _ in os.walk('.'):
+        for name in list(dirs):
+            if cache_dir.match(name):
+                shutil.rmtree(os.path.join(root, name), ignore_errors=True)
+                dirs.remove(name)

--- a/python/fibonacci_sequence/test/test_fibonacci.py
+++ b/python/fibonacci_sequence/test/test_fibonacci.py
@@ -10,5 +10,5 @@ from fibonacci import fibonacci
         (10, 10, [10, 11, 21, 32, 53, 85, 138, 223, 361, 584]),
     ],
 )
-def test_fibonacci(start, count, expected):
+def test_fibonacci(start: int, count: int, expected: list[int]) -> None:
     assert fibonacci(start, count) == expected

--- a/python/fizzbuzz/main.py
+++ b/python/fizzbuzz/main.py
@@ -1,4 +1,4 @@
-from fizzbuzz import *
+from fizzbuzz import fizzbuzz_in_if, fizzbuzz_in_ternary
 import sys
 import os
 import shutil

--- a/python/fizzbuzz/pyproject.toml
+++ b/python/fizzbuzz/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.mypy]
+python_version = "3.14"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true

--- a/python/fizzbuzz/src/fizzbuzz.py
+++ b/python/fizzbuzz/src/fizzbuzz.py
@@ -1,4 +1,4 @@
-def fizzbuzz_in_if(num):
+def fizzbuzz_in_if(num: int) -> str:
     if num % 3 == 0 and num % 5 == 0:
         result = 'FizzBuzz'
     elif num % 3 == 0:
@@ -10,7 +10,7 @@ def fizzbuzz_in_if(num):
     return result
 
 
-def fizzbuzz_in_ternary(num):
+def fizzbuzz_in_ternary(num: int) -> str:
     result = 'FizzBuzz' if num % 3 == 0 and num % 5 == 0 else 'Fizz' if num % 3 == 0 else 'Buzz' if num % 5 == 0 else str(
         num)
     return result

--- a/python/fizzbuzz/test/conftest.py
+++ b/python/fizzbuzz/test/conftest.py
@@ -1,17 +1,22 @@
+import pytest
 import glob
 import os
 import shutil
 import sys
+from collections.abc import Iterator
 
 sys.path.append('./src')
 
 
-import pytest
-
-
 @pytest.fixture(autouse=True)
-def _cleanup_pycaches():
-    before = set(glob.glob(os.path.join('.', '**', '__pycache__'), recursive=True))
+def __cleanup_caches__() -> Iterator[None]:
+    before = set(
+        glob.glob(
+            os.path.join(
+                '.',
+                '**',
+                '__pycache__'),
+            recursive=True))
     yield
     for pycache in before:
         if os.path.exists(pycache):

--- a/python/fizzbuzz/test/conftest.py
+++ b/python/fizzbuzz/test/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-import glob
+import re
 import os
 import shutil
 import sys
@@ -10,14 +10,10 @@ sys.path.append('./src')
 
 @pytest.fixture(autouse=True)
 def __cleanup_caches__() -> Iterator[None]:
-    before = set(
-        glob.glob(
-            os.path.join(
-                '.',
-                '**',
-                '__pycache__'),
-            recursive=True))
     yield
-    for pycache in before:
-        if os.path.exists(pycache):
-            shutil.rmtree(pycache)
+    cache_dir = re.compile(r'^(?:__pycache__|\.pytest_cache|\.mypy_cache)$')
+    for root, dirs, _ in os.walk('.'):
+        for name in list(dirs):
+            if cache_dir.match(name):
+                shutil.rmtree(os.path.join(root, name), ignore_errors=True)
+                dirs.remove(name)

--- a/python/fizzbuzz/test/test_fizzbuzz.py
+++ b/python/fizzbuzz/test/test_fizzbuzz.py
@@ -1,9 +1,11 @@
+from collections.abc import Callable
+
 import pytest
 
 from fizzbuzz import fizzbuzz_in_if, fizzbuzz_in_ternary
 
 
-def _expected(num):
+def _expected(num: int) -> str:
     if num % 3 == 0 and num % 5 == 0:
         return 'FizzBuzz'
     if num % 3 == 0:
@@ -13,7 +15,8 @@ def _expected(num):
     return str(num)
 
 
-@pytest.mark.parametrize('implementation', [fizzbuzz_in_if, fizzbuzz_in_ternary])
+@pytest.mark.parametrize('implementation',
+                         [fizzbuzz_in_if, fizzbuzz_in_ternary])
 @pytest.mark.parametrize('num', range(1, 101))
-def test_fizzbuzz(implementation, num):
+def test_fizzbuzz(implementation: Callable[[int], str], num: int) -> None:
     assert implementation(num) == _expected(num)

--- a/python/letter_inspection/pyproject.toml
+++ b/python/letter_inspection/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.mypy]
+python_version = "3.14"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true

--- a/python/letter_inspection/src/application.py
+++ b/python/letter_inspection/src/application.py
@@ -1,14 +1,14 @@
 class Application:
-    def __init__(self, str_1, str_2):
-        self.str_1 = str_1
-        self.str_2 = str_2
+    def __init__(self, str_1: str, str_2: str) -> None:
+        self.str_1: str = str_1
+        self.str_2: str = str_2
 
-    def exactly_equal_size_and_included(self):
+    def exactly_equal_size_and_included(self) -> bool:
         return self.__sort_string__(
             self.str_1) == self.__sort_string__(
             self.str_2)
 
     # private
 
-    def __sort_string__(self, str):
+    def __sort_string__(self, str: str) -> str:
         return ''.join(sorted(str))

--- a/python/letter_inspection/test/conftest.py
+++ b/python/letter_inspection/test/conftest.py
@@ -1,17 +1,22 @@
+import pytest
 import glob
 import os
 import shutil
 import sys
+from collections.abc import Iterator
 
 sys.path.append('./src')
 
 
-import pytest
-
-
 @pytest.fixture(autouse=True)
-def _cleanup_pycaches():
-    before = set(glob.glob(os.path.join('.', '**', '__pycache__'), recursive=True))
+def __cleanup_caches__() -> Iterator[None]:
+    before = set(
+        glob.glob(
+            os.path.join(
+                '.',
+                '**',
+                '__pycache__'),
+            recursive=True))
     yield
     for pycache in before:
         if os.path.exists(pycache):

--- a/python/letter_inspection/test/conftest.py
+++ b/python/letter_inspection/test/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-import glob
+import re
 import os
 import shutil
 import sys
@@ -10,14 +10,10 @@ sys.path.append('./src')
 
 @pytest.fixture(autouse=True)
 def __cleanup_caches__() -> Iterator[None]:
-    before = set(
-        glob.glob(
-            os.path.join(
-                '.',
-                '**',
-                '__pycache__'),
-            recursive=True))
     yield
-    for pycache in before:
-        if os.path.exists(pycache):
-            shutil.rmtree(pycache)
+    cache_dir = re.compile(r'^(?:__pycache__|\.pytest_cache|\.mypy_cache)$')
+    for root, dirs, _ in os.walk('.'):
+        for name in list(dirs):
+            if cache_dir.match(name):
+                shutil.rmtree(os.path.join(root, name), ignore_errors=True)
+                dirs.remove(name)

--- a/python/letter_inspection/test/test_application.py
+++ b/python/letter_inspection/test/test_application.py
@@ -11,5 +11,8 @@ from application import Application
         ('hogefoobar', 'piyopoopee', False),
     ],
 )
-def test_exactly_equal_size_and_included(str_1, str_2, expected):
-    assert Application(str_1=str_1, str_2=str_2).exactly_equal_size_and_included() is expected
+def test_exactly_equal_size_and_included(
+        str_1: str, str_2: str, expected: bool) -> None:
+    assert Application(
+        str_1=str_1,
+        str_2=str_2).exactly_equal_size_and_included() is expected

--- a/python/nabeatsu/main.py
+++ b/python/nabeatsu/main.py
@@ -1,4 +1,4 @@
-from nabeatsu import *
+from nabeatsu import go_crazy_in_if, go_crazy_in_ternary
 import sys
 import os
 import shutil

--- a/python/nabeatsu/pyproject.toml
+++ b/python/nabeatsu/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.mypy]
+python_version = "3.14"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true

--- a/python/nabeatsu/src/nabeatsu.py
+++ b/python/nabeatsu/src/nabeatsu.py
@@ -1,4 +1,4 @@
-def go_crazy_in_if(num):
+def go_crazy_in_if(num: int) -> str:
     if num % 3 == 0 or '3' in str(num):
         # Express the status of 'crazy' with '!'
         result = str(num) + '!'
@@ -7,7 +7,7 @@ def go_crazy_in_if(num):
     return result
 
 
-def go_crazy_in_ternary(num):
+def go_crazy_in_ternary(num: int) -> str:
     # Express the status of 'crazy' with '!'
     result = str(num) + '!' if num % 3 == 0 or '3' in str(num) else str(num)
     return result

--- a/python/nabeatsu/test/conftest.py
+++ b/python/nabeatsu/test/conftest.py
@@ -1,17 +1,22 @@
+import pytest
 import glob
 import os
 import shutil
 import sys
+from collections.abc import Iterator
 
 sys.path.append('./src')
 
 
-import pytest
-
-
 @pytest.fixture(autouse=True)
-def _cleanup_pycaches():
-    before = set(glob.glob(os.path.join('.', '**', '__pycache__'), recursive=True))
+def __cleanup_caches__() -> Iterator[None]:
+    before = set(
+        glob.glob(
+            os.path.join(
+                '.',
+                '**',
+                '__pycache__'),
+            recursive=True))
     yield
     for pycache in before:
         if os.path.exists(pycache):

--- a/python/nabeatsu/test/conftest.py
+++ b/python/nabeatsu/test/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-import glob
+import re
 import os
 import shutil
 import sys
@@ -10,14 +10,10 @@ sys.path.append('./src')
 
 @pytest.fixture(autouse=True)
 def __cleanup_caches__() -> Iterator[None]:
-    before = set(
-        glob.glob(
-            os.path.join(
-                '.',
-                '**',
-                '__pycache__'),
-            recursive=True))
     yield
-    for pycache in before:
-        if os.path.exists(pycache):
-            shutil.rmtree(pycache)
+    cache_dir = re.compile(r'^(?:__pycache__|\.pytest_cache|\.mypy_cache)$')
+    for root, dirs, _ in os.walk('.'):
+        for name in list(dirs):
+            if cache_dir.match(name):
+                shutil.rmtree(os.path.join(root, name), ignore_errors=True)
+                dirs.remove(name)

--- a/python/nabeatsu/test/test_nabeatsu.py
+++ b/python/nabeatsu/test/test_nabeatsu.py
@@ -1,13 +1,16 @@
+from collections.abc import Callable
+
 import pytest
 
 from nabeatsu import go_crazy_in_if, go_crazy_in_ternary
 
 
-def _expected(num):
+def _expected(num: int) -> str:
     return f'{num}!' if num % 3 == 0 or '3' in str(num) else str(num)
 
 
-@pytest.mark.parametrize('implementation', [go_crazy_in_if, go_crazy_in_ternary])
+@pytest.mark.parametrize('implementation',
+                         [go_crazy_in_if, go_crazy_in_ternary])
 @pytest.mark.parametrize('num', range(1, 41))
-def test_go_crazy(implementation, num):
+def test_go_crazy(implementation: Callable[[int], str], num: int) -> None:
     assert implementation(num) == _expected(num)

--- a/python/requirements.lock
+++ b/python/requirements.lock
@@ -1,9 +1,9 @@
-ast_serialize==0.3.0
+ast_serialize==0.5.0
 autoflake8==0.4.1
 autopep8==2.3.2
 flake8==7.3.0
 iniconfig==2.3.0
-librt==0.10.0
+librt==0.11.0
 mccabe==0.7.0
 mypy==2.0.0
 mypy_extensions==1.1.0

--- a/python/run_mypy.sh
+++ b/python/run_mypy.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-for directory in $(ls -d */)
-do
-  cd $directory
-  mypy .
-  cd ../
-done

--- a/python/run_mypy.sh
+++ b/python/run_mypy.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+for directory in $(ls -d */)
+do
+  cd $directory
+  mypy .
+  cd ../
+done

--- a/python/run_unittests.sh
+++ b/python/run_unittests.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-for directory in $(ls -d */)
-do
-  cd $directory
-  python -m unittest discover ./test
-  cd ../
-done


### PR DESCRIPTION
## 1. Why (Purpose)

Most personal Python projects had no static type checking, and code-style consistency was only partially enforced. The goals were to:

- **Introduce `mypy`** to every Python project so type regressions are caught in CI rather than at runtime.
- **Add reasonable type annotations** to the implementations (and add missing ones where mypy was partially present).
- **Enable the `mypy` job in GitHub Actions** so type checking runs on every push/PR (it was commented out in most workflows).
- **Enforce code convention** by running `autoflake8` + `autopep8` and fixing residual `flake8` violations, keeping the codebase clean and consistent.

## 2. What (Procedures)

Processed **13 Python repositories** (the `github-wiki-organisers-wiki` repo was skipped — the project is a git submodule there). Per project:

1. Ensured `mypy==2.0.0` in `requirements.txt` (added to `deep-learnings`, `natural-language-processing`).
2. Added a `[tool.mypy]` block in `pyproject.toml` (created where missing).
3. Added type annotations across `src/`, `test/`, `conftest.py`, `main.py`, `exec/` so `mypy` passes; fixed genuine type bugs found along the way (`*_` argv-unpack reuse, a literally-duplicated class in `embedding_dot.py`, a duplicated optional-import block, a missing `import urllib.parse`, `from X import *` → explicit imports).
4. Enabled the previously-commented `mypy` CI job; added `run_mypy.sh` for multi-subproject/volume repos to avoid duplicate-module collisions.
5. Ran `autoflake8 --in-place --remove-duplicate-keys --remove-unused-variables --recursive .` and `autopep8 --in-place --aggressive --aggressive --recursive .`, then fixed remaining `flake8` violations (E501, E402, E114/E131, F811, F403/F405).
6. Verified each unit with `mypy`, `flake8` (project CI settings), and `pytest`.

**Strictness policy:** application projects use strict config (`disallow_untyped_defs = true`, matching the existing `file-cleaners` convention); the numpy/learning repos (`tutorials`, `natural-language-processing`, `deep-learnings`) use a lenient config — mirroring the user's own pre-existing lenient `deep-learnings` setup.

**Commits:** two semantic units per repo on the existing topic branch, local only — *“Introduce mypy type checking”* (config/deps/CI/`run_mypy.sh`) and *“Apply autoflake8/autopep8 and fix flake8 violations”* (source pass). Repos already mypy-enabled got only the second commit.

A separate follow-up fix: `save_dicision_boundary_image` (deep-learnings vol2) didn’t open a fresh matplotlib figure, so it rendered onto the leftover loss-plot figure when the test suite ran in one process — corrupting `img/dicision_boundary.png`. Added `plt.figure()` and restored the curated original PNGs (commit `00ed73c`).

## 3. How (Operation and Maintenance)

- **Toolchain:** Windows had no usable Python; the toolchain (Python 3.14, mypy 2.0, flake8, autopep8, autoflake8, pytest) runs under **WSL Ubuntu**. Run all checks there against `/mnt/c/...`.
- **Run type checks:** single-unit projects — `mypy .` from the project dir. `coding-tests` — `bash run_mypy.sh` from `python/` (iterates the 5 subprojects). `deep-learnings` — `bash run_mypy.sh vol1|vol2` from repo root (root `pyproject.toml` config applies); `vol3` is checked per-chapter (intentionally reused module basenames, same reason pytest uses `--import-mode=importlib`).
- **Lint maintenance:** re-run the mandated `autoflake8`/`autopep8` pair, then `flake8 . --max-complexity=10 --max-line-length=127`.
- **CI:** `mypy` jobs are now active in the workflows; pushing the topic branches will exercise them on GitHub.
- **Caveat for maintainers:** several deep-learnings tests `savefig` directly into the tracked `img/` directory, so a full test run rewrites those committed PNGs (now correctly, after the figure fix). Consider redirecting test image output to a temp/untracked path.

## 4. Pros & Cons

### Pros

- Static type safety now enforced in CI across all projects; many latent bugs surfaced and fixed.
- Consistent, convention-compliant formatting; clean `flake8`/`mypy`/`pytest` across the board.
- Per-repo, semantically split commits make review and selective reverts easy.
- Pragmatic per-domain strictness keeps numpy/learning code maintainable without low-value churn.

### Cons & Trade-offs

- A few targeted `# type: ignore` for genuine pre-existing oddities (e.g. `list - dict_keys` valid only via `Set.__rsub__`); not full type purity.
- Type annotations and `autopep8` reflow are interleaved in the same files, so the two semantic commits split at the infra-vs-source boundary rather than purely "types vs lint".
- `autopep8 --aggressive --aggressive` produced some visually awkward wrapping (e.g. multi-line f-strings) — functional but not hand-tuned.
- `deep-learnings/vol2/train/` & `vol2/evaluate/` are pre-existing broken, non-tested experiment scripts — excluded from mypy rather than rewritten.

## 5. Others

- **Skipped:** `github-wiki-organisers-wiki` (the project is a git submodule of the `.wiki` repo — editing it would be wrong).
- **Nothing pushed** — all commits are local on the `hayat01sh1da/python/install-type-checking` topic branch in each repo, per request.
- **Pre-existing, out-of-scope issue flagged:** `natural-language-processing/.github/workflows/1_prereqiosotes.yml` has inconsistent path filters/filename (`vol1/**` vs `1_prerequisites`); left unchanged.
- **Environment-dependent tests:** `web-scrapers` (chromedriver) and `calculator_cli_app` (`CALCULATION_API`) passed in the WSL env but depend on external setup in CI.
- **Verification results:** all units green — e.g. github-wiki-organisers (mypy 14, pytest 32), web-scrapers (mypy 17, pytest 8), coding-tests (pytest 200/2/80/3/4), deep-learnings (mypy 42/108/all-chapters, pytest 48/153/15).