### PR TITLE
[ruby] Resolve All Violations against Convention reported by RuboCop

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -9,3 +9,9 @@ plugins:
 AllCops:
   TargetRubyVersion: 4.0
   NewCops: enable
+
+# Test directories live under each sub-app (e.g. fizzbuzz/test/) and are not
+# matched by the default top-level `test/**/*` glob, so list them here.
+Style/Documentation:
+  Exclude:
+    - '**/test/**/*'

--- a/ruby/.rubocop_todo.yml
+++ b/ruby/.rubocop_todo.yml
@@ -33,12 +33,3 @@ Style/Documentation:
     - 'letter_matching_inspection/test/application_test.rb'
     - 'nabeatsu/test/application_test.rb'
 
-# Offense count: 8
-# Configuration parameters: AllowedClasses.
-Style/OneClassPerFile:
-  Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
-    - 'calculator_cli_app/test/queries/calculation_query_test.rb'
-    - 'fibonacci_sequence/test/application_test.rb'
-    - 'fizzbuzz/test/application_test.rb'

--- a/ruby/.rubocop_todo.yml
+++ b/ruby/.rubocop_todo.yml
@@ -16,14 +16,6 @@ Metrics/AbcSize:
 Metrics/MethodLength:
   Max: 13
 
-# Offense count: 3
-# Configuration parameters: MinNameLength, AllowNamesEndingInNumbers, AllowedNames, ForbiddenNames.
-# AllowedNames: as, at, by, cc, db, id, if, in, io, ip, of, on, os, pp, to
-Naming/MethodParameterName:
-  Exclude:
-    - 'calculator_cli_app/src/queries/calculation_query.rb'
-    - 'calculator_cli_app/src/validations/args_validation.rb'
-
 # Offense count: 16
 # Configuration parameters: AllowedConstants.
 Style/Documentation:

--- a/ruby/.rubocop_todo.yml
+++ b/ruby/.rubocop_todo.yml
@@ -30,16 +30,6 @@ Naming/MethodParameterName:
     - 'calculator_cli_app/src/queries/calculation_query.rb'
     - 'calculator_cli_app/src/validations/args_validation.rb'
 
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: EnforcedStyle, EnforcedStyleForClasses, EnforcedStyleForModules.
-# SupportedStyles: nested, compact
-# SupportedStylesForClasses: ~, nested, compact
-# SupportedStylesForModules: ~, nested, compact
-Style/ClassAndModuleChildren:
-  Exclude:
-    - 'calculator_cli_app/test/application_test.rb'
-
 # Offense count: 16
 # Configuration parameters: AllowedConstants.
 Style/Documentation:
@@ -57,55 +47,10 @@ Style/Documentation:
     - 'letter_matching_inspection/test/application_test.rb'
     - 'nabeatsu/test/application_test.rb'
 
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-Style/EvenOdd:
-  Exclude:
-    - 'calculator_cli_app/src/queries/calculation_query.rb'
-
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowedVars, DefaultToNil.
-Style/FetchEnvVar:
-  Exclude:
-    - 'calculator_cli_app/src/queries/calculation_query.rb'
-
-# Offense count: 14
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: always, always_true, never
-Style/FrozenStringLiteralComment:
-  Exclude:
-    - '**/*.arb'
-    - 'Gemfile'
-    - 'calculator_cli_app/src/application.rb'
-    - 'calculator_cli_app/src/queries/calculation_query.rb'
-    - 'calculator_cli_app/src/validations/args_validation.rb'
-    - 'calculator_cli_app/test/application_test.rb'
-    - 'calculator_cli_app/test/queries/calculation_query_test.rb'
-    - 'fibonacci_sequence/src/application.rb'
-    - 'fibonacci_sequence/test/application_test.rb'
-    - 'fizzbuzz/src/application.rb'
-    - 'fizzbuzz/test/application_test.rb'
-    - 'letter_matching_inspection/src/application.rb'
-    - 'letter_matching_inspection/test/application_test.rb'
-    - 'nabeatsu/src/application.rb'
-    - 'nabeatsu/test/application_test.rb'
-
 # Offense count: 2
 Style/MultilineBlockChain:
   Exclude:
     - 'Rakefile'
-
-# Offense count: 3
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: EnforcedStyle, AllowedMethods, AllowedPatterns.
-# SupportedStyles: predicate, comparison
-Style/NumericPredicate:
-  Exclude:
-    - 'spec/**/*'
-    - 'calculator_cli_app/src/queries/calculation_query.rb'
-    - 'calculator_cli_app/src/validations/args_validation.rb'
 
 # Offense count: 8
 # Configuration parameters: AllowedClasses.
@@ -116,9 +61,3 @@ Style/OneClassPerFile:
     - 'calculator_cli_app/test/queries/calculation_query_test.rb'
     - 'fibonacci_sequence/test/application_test.rb'
     - 'fizzbuzz/test/application_test.rb'
-
-# Offense count: 2
-# This cop supports safe autocorrection (--autocorrect).
-Style/RedundantCurrentDirectoryInPath:
-  Exclude:
-    - 'calculator_cli_app/src/application.rb'

--- a/ruby/.rubocop_todo.yml
+++ b/ruby/.rubocop_todo.yml
@@ -6,16 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 3
-# Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes.
-Metrics/AbcSize:
-  Max: 20
-
-# Offense count: 4
-# Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns.
-Metrics/MethodLength:
-  Max: 13
-
 # Offense count: 16
 # Configuration parameters: AllowedConstants.
 Style/Documentation:

--- a/ruby/.rubocop_todo.yml
+++ b/ruby/.rubocop_todo.yml
@@ -7,12 +7,6 @@
 # versions of RuboCop, may require this file to be generated again.
 
 # Offense count: 3
-# Configuration parameters: AllowKeywordBlockArguments.
-Lint/UnderscorePrefixedVariableName:
-  Exclude:
-    - 'Rakefile'
-
-# Offense count: 3
 # Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes.
 Metrics/AbcSize:
   Max: 20
@@ -46,11 +40,6 @@ Style/Documentation:
     - 'letter_matching_inspection/src/application.rb'
     - 'letter_matching_inspection/test/application_test.rb'
     - 'nabeatsu/test/application_test.rb'
-
-# Offense count: 2
-Style/MultilineBlockChain:
-  Exclude:
-    - 'Rakefile'
 
 # Offense count: 8
 # Configuration parameters: AllowedClasses.

--- a/ruby/.rubocop_todo.yml
+++ b/ruby/.rubocop_todo.yml
@@ -6,20 +6,3 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 16
-# Configuration parameters: AllowedConstants.
-Style/Documentation:
-  Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
-    - 'calculator_cli_app/src/application.rb'
-    - 'calculator_cli_app/src/queries/calculation_query.rb'
-    - 'calculator_cli_app/src/validations/args_validation.rb'
-    - 'calculator_cli_app/test/application_test.rb'
-    - 'calculator_cli_app/test/queries/calculation_query_test.rb'
-    - 'fibonacci_sequence/test/application_test.rb'
-    - 'fizzbuzz/test/application_test.rb'
-    - 'letter_matching_inspection/src/application.rb'
-    - 'letter_matching_inspection/test/application_test.rb'
-    - 'nabeatsu/test/application_test.rb'
-

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem 'rbs-inline', '~> 0.14.0', require: false

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -22,7 +22,7 @@ Rake::Task.define_task(:print_fibonacci_sequence) do
   puts 'Provide the number of iterations'
   iter = $stdin.gets&.chomp&.strip
 
-  params = { init_num:, iter: }.reject { |_, value| value&.empty? }.to_h { |_, value| [_, value.to_i] }
+  params = { init_num:, iter: }.reject { |_, value| value&.empty? }.transform_values(&:to_i)
   puts fibonacci(**params).join(', ')
 end
 
@@ -37,9 +37,9 @@ Rake::Task.define_task(:print_fizzbuzz_sequence) do
   puts 'Which logic do you want to use? (1: if, 2: if and ternary, 3: ternary)'
   logic_type = $stdin.gets&.chomp&.strip
 
-  params = { init_num:, terminal_num:, logic_type: }.reject do |_, value|
-    value&.empty?
-  end.to_h { |_, value| [_, value.to_i] }
+  params = { init_num:, terminal_num:, logic_type: }
+           .reject { |_, value| value&.empty? }
+           .transform_values(&:to_i)
   init_num, terminal_num, logic_type = params.values_at(:init_num, :terminal_num, :logic_type)
 
   result = init_num.upto(terminal_num).map do |num|
@@ -81,9 +81,9 @@ Rake::Task.define_task(:print_nabeatsu_sequence) do
   puts 'Which logic do you want to use? (1: if, 2: ternary)'
   logic_type = $stdin.gets&.chomp&.strip
 
-  params = { init_num:, terminal_num:, logic_type: }.reject do |_, value|
-    value&.empty?
-  end.to_h { |_, value| [_, value.to_i] }
+  params = { init_num:, terminal_num:, logic_type: }
+           .reject { |_, value| value&.empty? }
+           .transform_values(&:to_i)
   init_num, terminal_num, logic_type = params.values_at(:init_num, :terminal_num, :logic_type)
 
   result = init_num.upto(terminal_num).map do |num|

--- a/ruby/calculator_cli_app/src/application.rb
+++ b/ruby/calculator_cli_app/src/application.rb
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
 # rbs_inline: enabled
 
-require_relative './queries/calculation_query'
-require_relative './validations/args_validation'
+require_relative 'queries/calculation_query'
+require_relative 'validations/args_validation'
 
 module CalculatorCliApp
   class Application

--- a/ruby/calculator_cli_app/src/application.rb
+++ b/ruby/calculator_cli_app/src/application.rb
@@ -5,6 +5,7 @@ require_relative 'queries/calculation_query'
 require_relative 'validations/args_validation'
 
 module CalculatorCliApp
+  # Validates the CLI args and prints the result of CalculationQuery#f for them.
   class Application
     include ::Validations::ArgsValidation
 

--- a/ruby/calculator_cli_app/src/queries/calculation_query.rb
+++ b/ruby/calculator_cli_app/src/queries/calculation_query.rb
@@ -5,6 +5,8 @@ require 'net/http'
 require 'json'
 
 module Queries
+  # Recursive calculator that handles base cases locally and delegates odd
+  # values of num to a remote calculation service.
   class CalculationQuery
     # @rbs seed: String
     # @rbs return: void

--- a/ruby/calculator_cli_app/src/queries/calculation_query.rb
+++ b/ruby/calculator_cli_app/src/queries/calculation_query.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # rbs_inline: enabled
 
 require 'net/http'
@@ -14,11 +15,11 @@ module Queries
     # @rbs n: Integer
     # @rbs return: Integer
     def f(n)
-      if n == 0
+      if n.zero?
         1
       elsif n == 2
         2
-      elsif n % 2 == 0
+      elsif n.even?
         f(n - 1) + f(n - 2) + f(n - 3) + f(n - 4)
       else
         ask_server(n)

--- a/ruby/calculator_cli_app/src/queries/calculation_query.rb
+++ b/ruby/calculator_cli_app/src/queries/calculation_query.rb
@@ -12,17 +12,17 @@ module Queries
       @seed = seed
     end
 
-    # @rbs n: Integer
+    # @rbs num: Integer
     # @rbs return: Integer
-    def f(n)
-      if n.zero?
+    def f(num)
+      if num.zero?
         1
-      elsif n == 2
+      elsif num == 2
         2
-      elsif n.even?
-        f(n - 1) + f(n - 2) + f(n - 3) + f(n - 4)
+      elsif num.even?
+        f(num - 1) + f(num - 2) + f(num - 3) + f(num - 4)
       else
-        ask_server(n)
+        ask_server(num)
       end
     end
 
@@ -35,11 +35,10 @@ module Queries
       @uri ||= URI.parse(ENV.fetch('CALCULATION_API'))
     end
 
-    # @rbs n: Integer
+    # @rbs num: Integer
     # @rbs return: Integer
-    def ask_server(n)
-      params    = { seed:, n: }
-      uri.query = URI.encode_www_form(params)
+    def ask_server(num)
+      uri.query = URI.encode_www_form(seed:, n: num)
       req       = Net::HTTP::Get.new(uri)
       res       = Net::HTTP.start(uri.host.to_s, uri.port) { |http| http.request(req) }
       JSON.parse(res.body)['result']

--- a/ruby/calculator_cli_app/src/validations/args_validation.rb
+++ b/ruby/calculator_cli_app/src/validations/args_validation.rb
@@ -9,19 +9,26 @@ module Validations
     # @rbs num: Integer?
     # @rbs return: void
     def validate!(args_size, seed, num)
-      if args_size > 2
-        puts 'Too many arguments'
-        exit 1
-      elsif args_size.zero?
-        puts 'No argument provided'
-        exit 1
-      elsif args_size == 1
-        puts 'Provide both seed and n'
-        exit 1
-      elsif !seed.instance_of?(String) || num.nil?
-        puts 'Provide seed as string and n as number'
-        exit 1
-      end
+      message = validation_error(args_size, seed, num)
+      return unless message
+
+      puts message
+      exit 1
+    end
+
+    private
+
+    # @rbs args_size: Integer
+    # @rbs seed: String
+    # @rbs num: Integer?
+    # @rbs return: String?
+    def validation_error(args_size, seed, num)
+      return 'Too many arguments'                     if args_size > 2
+      return 'No argument provided'                   if args_size.zero?
+      return 'Provide both seed and n'                if args_size == 1
+      return 'Provide seed as string and n as number' if !seed.instance_of?(String) || num.nil?
+
+      nil
     end
   end
 end

--- a/ruby/calculator_cli_app/src/validations/args_validation.rb
+++ b/ruby/calculator_cli_app/src/validations/args_validation.rb
@@ -2,6 +2,7 @@
 # rbs_inline: enabled
 
 module Validations
+  # Argument-shape checks for CalculatorCliApp::Application.
   module ArgsValidation
     # @rbs args_size: Integer
     # @rbs seed: String

--- a/ruby/calculator_cli_app/src/validations/args_validation.rb
+++ b/ruby/calculator_cli_app/src/validations/args_validation.rb
@@ -5,9 +5,9 @@ module Validations
   module ArgsValidation
     # @rbs args_size: Integer
     # @rbs seed: String
-    # @rbs n: Integer?
+    # @rbs num: Integer?
     # @rbs return: void
-    def validate!(args_size, seed, n)
+    def validate!(args_size, seed, num)
       if args_size > 2
         puts 'Too many arguments'
         exit 1
@@ -17,7 +17,7 @@ module Validations
       elsif args_size == 1
         puts 'Provide both seed and n'
         exit 1
-      elsif !seed.instance_of?(String) || n.nil?
+      elsif !seed.instance_of?(String) || num.nil?
         puts 'Provide seed as string and n as number'
         exit 1
       end

--- a/ruby/calculator_cli_app/src/validations/args_validation.rb
+++ b/ruby/calculator_cli_app/src/validations/args_validation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # rbs_inline: enabled
 
 module Validations
@@ -10,7 +11,7 @@ module Validations
       if args_size > 2
         puts 'Too many arguments'
         exit 1
-      elsif args_size == 0
+      elsif args_size.zero?
         puts 'No argument provided'
         exit 1
       elsif args_size == 1

--- a/ruby/calculator_cli_app/test/application_test.rb
+++ b/ruby/calculator_cli_app/test/application_test.rb
@@ -1,18 +1,21 @@
+# frozen_string_literal: true
 # rbs_inline: enabled
 
 require 'minitest/autorun'
 require_relative '../src/application'
 
-class CalculatorCliApp::ApplicationTest < Minitest::Test
-  def setup
-    @argv = ['foo', 4]
+module CalculatorCliApp
+  class ApplicationTest < Minitest::Test
+    def setup
+      @argv = ['foo', 4]
+    end
+
+    def test_run_success
+      assert_output("348\n") { ::CalculatorCliApp::Application.run!(argv) }
+    end
+
+    private
+
+    attr_reader :argv
   end
-
-  def test_run_success
-    assert_output("348\n") { ::CalculatorCliApp::Application.run!(argv) }
-  end
-
-  private
-
-  attr_reader :argv
 end

--- a/ruby/calculator_cli_app/test/queries/calculation_query_test.rb
+++ b/ruby/calculator_cli_app/test/queries/calculation_query_test.rb
@@ -9,25 +9,15 @@ class CalculationQueryTest < Minitest::Test
     @calculation_query = ::Queries::CalculationQuery.new('foo')
   end
 
-  private
-
-  attr_reader :calculation_query
-end
-
-class ArgumentZeroTest < CalculationQueryTest
-  def test_f
-    assert_equal(1, calculation_query.f(0))
+  def test_f_returns_one_when_argument_is_zero
+    assert_equal(1, @calculation_query.f(0))
   end
-end
 
-class ArgumentTwoTest < CalculationQueryTest
-  def test_f
-    assert_equal(2, calculation_query.f(2))
+  def test_f_returns_two_when_argument_is_two
+    assert_equal(2, @calculation_query.f(2))
   end
-end
 
-class ArgumentFourTest < CalculationQueryTest
-  def test_f
-    assert_equal(348, calculation_query.f(4))
+  def test_f_recurses_for_an_even_argument
+    assert_equal(348, @calculation_query.f(4))
   end
 end

--- a/ruby/calculator_cli_app/test/queries/calculation_query_test.rb
+++ b/ruby/calculator_cli_app/test/queries/calculation_query_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # rbs_inline: enabled
 
 require 'minitest/autorun'

--- a/ruby/fibonacci_sequence/src/application.rb
+++ b/ruby/fibonacci_sequence/src/application.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # rbs_inline: enabled
 
 # @rbs init_num: Integer

--- a/ruby/fibonacci_sequence/test/application_test.rb
+++ b/ruby/fibonacci_sequence/test/application_test.rb
@@ -4,19 +4,15 @@
 require 'minitest/autorun'
 require_relative '../src/application'
 
-class ApplicationTest < Minitest::Test; end
-
-class TestCase1 < ApplicationTest
-  def test_fibonacci
+class ApplicationTest < Minitest::Test
+  def test_fibonacci_from_zero
     assert_equal(
       [0, 1, 1, 2, 3, 5, 8, 13, 21, 34],
       fibonacci(init_num: 0, iter: 10)
     )
   end
-end
 
-class TestCase2 < ApplicationTest
-  def test_fibonacci
+  def test_fibonacci_from_ten
     assert_equal(
       [10, 11, 21, 32, 53, 85, 138, 223, 361, 584],
       fibonacci(init_num: 10, iter: 10)

--- a/ruby/fibonacci_sequence/test/application_test.rb
+++ b/ruby/fibonacci_sequence/test/application_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # rbs_inline: enabled
 
 require 'minitest/autorun'

--- a/ruby/fizzbuzz/src/application.rb
+++ b/ruby/fizzbuzz/src/application.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # rbs_inline: enabled
 
 # @rbs num: Integer

--- a/ruby/fizzbuzz/test/application_test.rb
+++ b/ruby/fizzbuzz/test/application_test.rb
@@ -4,52 +4,32 @@
 require 'minitest/autorun'
 require_relative '../src/application'
 
-class ApplicationTest < Minitest::Test; end
+class ApplicationTest < Minitest::Test
+  def test_fizzbuzz_in_if
+    assert_fizzbuzz_sequence(:fizzbuzz_in_if)
+  end
 
-class IfStatementTest < ApplicationTest
-  def test_fizzbuzz
+  def test_fizzbuzz_in_ternary
+    assert_fizzbuzz_sequence(:fizzbuzz_in_ternary)
+  end
+
+  def test_fizzbuzz_in_if_and_ternary
+    assert_fizzbuzz_sequence(:fizzbuzz_in_if_and_ternary)
+  end
+
+  private
+
+  def assert_fizzbuzz_sequence(impl)
     1.upto(100).each do |num|
-      if (num % 3).zero? && (num % 5).zero?
-        assert_equal 'FizzBuzz', fizzbuzz_in_if(num)
-      elsif (num % 3).zero?
-        assert_equal 'Fizz', fizzbuzz_in_if(num)
-      elsif (num % 5).zero?
-        assert_equal 'Buzz', fizzbuzz_in_if(num)
-      else
-        assert_equal num.to_s, fizzbuzz_in_if(num)
-      end
+      assert_equal expected_for(num), send(impl, num)
     end
   end
-end
 
-class TernaryStatementTest < ApplicationTest
-  def test_fizzbuzz
-    1.upto(100).each do |num|
-      if (num % 3).zero? && (num % 5).zero?
-        assert_equal 'FizzBuzz', fizzbuzz_in_ternary(num)
-      elsif (num % 3).zero?
-        assert_equal 'Fizz', fizzbuzz_in_ternary(num)
-      elsif (num % 5).zero?
-        assert_equal 'Buzz', fizzbuzz_in_ternary(num)
-      else
-        assert_equal num.to_s, fizzbuzz_in_ternary(num)
-      end
-    end
-  end
-end
+  def expected_for(num)
+    return 'FizzBuzz' if (num % 15).zero?
+    return 'Fizz'     if (num % 3).zero?
+    return 'Buzz'     if (num % 5).zero?
 
-class HybridStatementTest < ApplicationTest
-  def test_fizzbuzz
-    1.upto(100).each do |num|
-      if (num % 3).zero? && (num % 5).zero?
-        assert_equal 'FizzBuzz', fizzbuzz_in_if_and_ternary(num)
-      elsif (num % 3).zero?
-        assert_equal 'Fizz', fizzbuzz_in_if_and_ternary(num)
-      elsif (num % 5).zero?
-        assert_equal 'Buzz', fizzbuzz_in_if_and_ternary(num)
-      else
-        assert_equal num.to_s, fizzbuzz_in_if_and_ternary(num)
-      end
-    end
+    num.to_s
   end
 end

--- a/ruby/fizzbuzz/test/application_test.rb
+++ b/ruby/fizzbuzz/test/application_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # rbs_inline: enabled
 
 require 'minitest/autorun'

--- a/ruby/letter_matching_inspection/src/application.rb
+++ b/ruby/letter_matching_inspection/src/application.rb
@@ -2,6 +2,7 @@
 # rbs_inline: enabled
 
 module LetterMatchingInspection
+  # Returns true when source and target are made up of exactly the same letters.
   class Application
     # @rbs source: String
     # @rbs target: String

--- a/ruby/letter_matching_inspection/src/application.rb
+++ b/ruby/letter_matching_inspection/src/application.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # rbs_inline: enabled
 
 module LetterMatchingInspection

--- a/ruby/letter_matching_inspection/test/application_test.rb
+++ b/ruby/letter_matching_inspection/test/application_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require_relative '../src/application'
 

--- a/ruby/nabeatsu/src/application.rb
+++ b/ruby/nabeatsu/src/application.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # rbs_inline: enabled
 
 # @rbs num: Integer

--- a/ruby/nabeatsu/test/application_test.rb
+++ b/ruby/nabeatsu/test/application_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # rbs_inline: enabled
 
 require 'minitest/autorun'

--- a/ruby/sig/generated/calculator_cli_app/src/application.rbs
+++ b/ruby/sig/generated/calculator_cli_app/src/application.rbs
@@ -1,6 +1,7 @@
 # Generated from calculator_cli_app/src/application.rb with RBS::Inline
 
 module CalculatorCliApp
+  # Validates the CLI args and prints the result of CalculationQuery#f for them.
   class Application
     include ::Validations::ArgsValidation
 

--- a/ruby/sig/generated/calculator_cli_app/src/queries/calculation_query.rbs
+++ b/ruby/sig/generated/calculator_cli_app/src/queries/calculation_query.rbs
@@ -1,14 +1,16 @@
 # Generated from calculator_cli_app/src/queries/calculation_query.rb with RBS::Inline
 
 module Queries
+  # Recursive calculator that handles base cases locally and delegates odd
+  # values of num to a remote calculation service.
   class CalculationQuery
     # @rbs seed: String
     # @rbs return: void
     def initialize: (String seed) -> void
 
-    # @rbs n: Integer
+    # @rbs num: Integer
     # @rbs return: Integer
-    def f: (Integer n) -> Integer
+    def f: (Integer num) -> Integer
 
     private
 
@@ -17,8 +19,8 @@ module Queries
     # @rbs return: URI::Generic
     def uri: () -> URI::Generic
 
-    # @rbs n: Integer
+    # @rbs num: Integer
     # @rbs return: Integer
-    def ask_server: (Integer n) -> Integer
+    def ask_server: (Integer num) -> Integer
   end
 end

--- a/ruby/sig/generated/calculator_cli_app/src/validations/args_validation.rbs
+++ b/ruby/sig/generated/calculator_cli_app/src/validations/args_validation.rbs
@@ -1,11 +1,20 @@
 # Generated from calculator_cli_app/src/validations/args_validation.rb with RBS::Inline
 
 module Validations
+  # Argument-shape checks for CalculatorCliApp::Application.
   module ArgsValidation
     # @rbs args_size: Integer
     # @rbs seed: String
-    # @rbs n: Integer?
+    # @rbs num: Integer?
     # @rbs return: void
-    def validate!: (Integer args_size, String seed, Integer? n) -> void
+    def validate!: (Integer args_size, String seed, Integer? num) -> void
+
+    private
+
+    # @rbs args_size: Integer
+    # @rbs seed: String
+    # @rbs num: Integer?
+    # @rbs return: String?
+    def validation_error: (Integer args_size, String seed, Integer? num) -> String?
   end
 end

--- a/ruby/sig/generated/calculator_cli_app/test/application_test.rbs
+++ b/ruby/sig/generated/calculator_cli_app/test/application_test.rbs
@@ -1,11 +1,13 @@
 # Generated from calculator_cli_app/test/application_test.rb with RBS::Inline
 
-class CalculatorCliApp::ApplicationTest < Minitest::Test
-  def setup: () -> untyped
+module CalculatorCliApp
+  class ApplicationTest < Minitest::Test
+    def setup: () -> untyped
 
-  def test_run_success: () -> untyped
+    def test_run_success: () -> untyped
 
-  private
+    private
 
-  attr_reader argv: untyped
+    attr_reader argv: untyped
+  end
 end

--- a/ruby/sig/generated/calculator_cli_app/test/queries/calculation_query_test.rbs
+++ b/ruby/sig/generated/calculator_cli_app/test/queries/calculation_query_test.rbs
@@ -3,19 +3,9 @@
 class CalculationQueryTest < Minitest::Test
   def setup: () -> untyped
 
-  private
+  def test_f_returns_one_when_argument_is_zero: () -> untyped
 
-  attr_reader calculation_query: untyped
-end
+  def test_f_returns_two_when_argument_is_two: () -> untyped
 
-class ArgumentZeroTest < CalculationQueryTest
-  def test_f: () -> untyped
-end
-
-class ArgumentTwoTest < CalculationQueryTest
-  def test_f: () -> untyped
-end
-
-class ArgumentFourTest < CalculationQueryTest
-  def test_f: () -> untyped
+  def test_f_recurses_for_an_even_argument: () -> untyped
 end

--- a/ruby/sig/generated/fibonacci_sequence/test/application_test.rbs
+++ b/ruby/sig/generated/fibonacci_sequence/test/application_test.rbs
@@ -1,12 +1,7 @@
 # Generated from fibonacci_sequence/test/application_test.rb with RBS::Inline
 
 class ApplicationTest < Minitest::Test
-end
+  def test_fibonacci_from_zero: () -> untyped
 
-class TestCase1 < ApplicationTest
-  def test_fibonacci: () -> untyped
-end
-
-class TestCase2 < ApplicationTest
-  def test_fibonacci: () -> untyped
+  def test_fibonacci_from_ten: () -> untyped
 end

--- a/ruby/sig/generated/fizzbuzz/test/application_test.rbs
+++ b/ruby/sig/generated/fizzbuzz/test/application_test.rbs
@@ -1,16 +1,15 @@
 # Generated from fizzbuzz/test/application_test.rb with RBS::Inline
 
 class ApplicationTest < Minitest::Test
-end
+  def test_fizzbuzz_in_if: () -> untyped
 
-class IfStatementTest < ApplicationTest
-  def test_fizzbuzz: () -> untyped
-end
+  def test_fizzbuzz_in_ternary: () -> untyped
 
-class TernaryStatementTest < ApplicationTest
-  def test_fizzbuzz: () -> untyped
-end
+  def test_fizzbuzz_in_if_and_ternary: () -> untyped
 
-class HybridStatementTest < ApplicationTest
-  def test_fizzbuzz: () -> untyped
+  private
+
+  def assert_fizzbuzz_sequence: (untyped impl) -> untyped
+
+  def expected_for: (untyped num) -> untyped
 end

--- a/ruby/sig/generated/letter_matching_inspection/src/application.rbs
+++ b/ruby/sig/generated/letter_matching_inspection/src/application.rbs
@@ -1,6 +1,7 @@
 # Generated from letter_matching_inspection/src/application.rb with RBS::Inline
 
 module LetterMatchingInspection
+  # Returns true when source and target are made up of exactly the same letters.
   class Application
     # @rbs source: String
     # @rbs target: String


### PR DESCRIPTION
## 1. Summary

Resolve all violations against Ruby convention reported by RuboCop listed on `rubocop_todo.yml`.

## 2. Commits

- [Resolve autocorrectable RuboCop violations](https://github.com/hayat01sh1da/coding-tests/pull/86/changes/ba3130471b7526c08ed3124a3d327ee71a4f26d5)
- [Resolve Lint/UnderscorePrefixedVariableName and Style/MultilineBlockChain](https://github.com/hayat01sh1da/coding-tests/pull/86/changes/c7a93bd2ffe293ed36dc49a4ac958d7243e15066)
- [Resolve Naming/MethodParameterName](https://github.com/hayat01sh1da/coding-tests/pull/86/changes/c6a2193e91fc6594d4381f40a58b9ba23068e88a)
- [Resolve Style/OneClassPerFile](https://github.com/hayat01sh1da/coding-tests/pull/86/changes/43360db457ca12b4915edeb35c03c485990f7aa0)
- [Resolve Metrics/AbcSize and Metrics/MethodLength](https://github.com/hayat01sh1da/coding-tests/pull/86/changes/86d5238cc7d8bdce5231c52c050aa95084e1397a)
- [Resolve Style/Documentation](https://github.com/hayat01sh1da/coding-tests/pull/86/changes/8d91b955b06df93efa5847ad2c9c89e62a5a98b8)
- [Exclude per-subapp test directories from Style/Documentation](https://github.com/hayat01sh1da/coding-tests/pull/86/changes/486bac9563defc8f24c4017e631da2d1993de32f)
- [Resolve Metrics/MethodLength in ArgsValidation#validate!](https://github.com/hayat01sh1da/coding-tests/pull/86/changes/d38035784dc9215b05f31113fcdf1dbd55eb97a7)
- [Update RBS signature files](https://github.com/hayat01sh1da/coding-tests/pull/86/commits/ff3d7c14139f8c774ac67fdc2d4d5be5cd11a936)