### PR TITLE
[ruby] Update Gem Dependencies

### DIFF
--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
     ffi (1.17.4-x86_64-linux-gnu)
     ffi (1.17.4-x86_64-linux-musl)
     fileutils (1.8.0)
-    json (2.19.5)
+    json (2.19.8)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     listen (3.10.0)
@@ -113,7 +113,7 @@ DEPENDENCIES
 
 CHECKSUMS
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
-  bundler (4.0.12) sha256=7f8b757d28dfb636e7b24fba2344ac6dd13b5b24f4b46d62573d483f211825ac
+  bundler (4.0.13) sha256=19f08be7f27022cf0b89f27da0b044ae075e8270a9ef44ad248a932614e1ca3b
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
   ffi (1.17.4) sha256=bcd1642e06f0d16fc9e09ac6d49c3a7298b9789bcb58127302f934e437d60acf
@@ -128,7 +128,7 @@ CHECKSUMS
   ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
   ffi (1.17.4-x86_64-linux-musl) sha256=3fdf9888483de005f8ef8d1cf2d3b20d86626af206cbf780f6a6a12439a9c49e
   fileutils (1.8.0) sha256=8c6b1df54e2540bdb2f39258f08af78853aa70bad52b4d394bbc6424593c6e02
-  json (2.19.5) sha256=218a18553e4801d579ca7e0f5bc72bafd776d7397238a1fb4e74db5b0a812c59
+  json (2.19.8) sha256=6354310fd76ef69b87d5bd1f38b40d730613baf90b6803d2d0a48f618d32dfaa
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   listen (3.10.0) sha256=c6e182db62143aeccc2e1960033bebe7445309c7272061979bb098d03760c9d2
@@ -158,4 +158,4 @@ CHECKSUMS
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH
-  4.0.12
+  4.0.13


### PR DESCRIPTION
## 1. Overview

This PR is a small maintenance update for the `ruby` directory's `Gemfile.lock`.  
It bumps Bundler from `4.0.12` to `4.0.13` (both the `CHECKSUMS` entry and `BUNDLED WITH`) and upgrades the `json` gem.  
No application code or Gemfile constraints change.

## 2. Key Changes

- **bundler `4.0.12` → `4.0.13`** — Maintenance/security release: Windows install of symlink-bearing gems (copies instead of symlinking), CWE-59 mitigation for archive extraction escaping the destination via pre-existing symlinks, `bundle outdated` now reports release dates, gem-publish "cooldown" support, and assorted compact-index and process-locking hardening.
- **json `2.19.5` → `2.19.8`** — Cumulative bug-fix bumps across `2.19.6`–`2.19.8`: fixes a 1-byte buffer over-read on EOS errors, handles invalid types passed as the `max_nesting` option, adds missing GC write barriers (`ParserConfig`, `State#dup`), prevents the string passed to `JSON.parse` from mutating during parsing, and improves handling of excessively large generator depth and out-of-range floats.

## 3. Summary

A minimal, low-risk lockfile refresh — only Bundler and `json` move, both via patch-level releases consisting entirely of bug fixes and safety/security hardening.  
No breaking changes and nothing for callers to adapt to.

## 4. References

- [bundler/CHANGELOG.md > 4.0.13 / 2026-06-03](https://github.com/ruby/rubygems/blob/master/bundler/CHANGELOG.md#4013--2026-06-03)
  - [Comparing changes between 4.0.12 and 4.0.13](https://github.com/ruby/rubygems/compare/v4.0.12...v4.0.13)
- [json/CHANGELOG.md > 2026-06-03 (2.19.8)](https://github.com/ruby/json/blob/master/CHANGES.md#2026-06-03-2198)
  - [Comparing changes between v2.19.5 and v2.19.8](https://github.com/ruby/json/compare/v2.19.5...v2.19.8)