### PR TITLE
[javascript] Update Package Dependecies

### DIFF
--- a/javascript/README.md
+++ b/javascript/README.md
@@ -1,7 +1,7 @@
 ## 1. Environment
 
 - Node v26.3.0
-- pnpm 11.5.1
+- pnpm 11.5.2
 
 ## 2. JEST install for Unit Test
 

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coding-test-js",
   "version": "1.0.0",
-  "description": "* WSL(Ubuntu 25.10 (GNU/Linux 6.6.87.2-microsoft-standard-WSL2 x86_64)) * Node.js v26.3.0 * pnpm 11.5.1",
+  "description": "* WSL(Ubuntu 25.10 (GNU/Linux 6.6.87.2-microsoft-standard-WSL2 x86_64)) * Node.js v26.3.0 * pnpm 11.5.2",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/javascript/pnpm-lock.yaml
+++ b/javascript/pnpm-lock.yaml
@@ -1094,8 +1094,8 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
-  electron-to-chromium@1.5.366:
-    resolution: {integrity: sha512-OlRuhb688YTCzzU3gXPLn6nGyd+F+53INE1qaKKlu6kETErE8FYsyDh0XqXEU+uBRn0MpCzz2vfNwORhkap8qg==}
+  electron-to-chromium@1.5.368:
+    resolution: {integrity: sha512-7RckJJK4uESJF9PxvfMWd3TGqIiieUTG4HxnKaKuIpGbcr+r2ZEB3g2gAhCP3Fqm42vJSzLfgab9eva/C4/XVw==}
 
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -1611,8 +1611,8 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.8.1:
-    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
+  semver@7.8.2:
+    resolution: {integrity: sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -3026,7 +3026,7 @@ snapshots:
     dependencies:
       baseline-browser-mapping: 2.10.33
       caniuse-lite: 1.0.30001793
-      electron-to-chromium: 1.5.366
+      electron-to-chromium: 1.5.368
       node-releases: 2.0.47
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
@@ -3097,7 +3097,7 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  electron-to-chromium@1.5.366: {}
+  electron-to-chromium@1.5.368: {}
 
   emittery@0.13.1: {}
 
@@ -3239,7 +3239,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@istanbuljs/schema': 0.1.6
       istanbul-lib-coverage: 3.2.2
-      semver: 7.8.1
+      semver: 7.8.2
     transitivePeerDependencies:
       - supports-color
 
@@ -3524,7 +3524,7 @@ snapshots:
       jest-message-util: 30.4.1
       jest-util: 30.4.1
       pretty-format: 30.4.1
-      semver: 7.8.1
+      semver: 7.8.2
       synckit: 0.11.13
     transitivePeerDependencies:
       - supports-color
@@ -3610,7 +3610,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.8.1
+      semver: 7.8.2
 
   makeerror@1.0.12:
     dependencies:
@@ -3753,7 +3753,7 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.8.1: {}
+  semver@7.8.2: {}
 
   shebang-command@2.0.0:
     dependencies:


### PR DESCRIPTION
## 1. Overview

This PR is a small maintenance update for the `javascript` directory.
It bumps the pinned **pnpm** version from `11.5.1` to `11.5.2` (in both `README.md` and the `package.json` description field) and refreshes two transitive dependencies in `pnpm-lock.yaml`.
No application code, no direct dependency constraints, and no `package.json` `dependencies`/`devDependencies` entries change — only the lockfile is regenerated.

## 2. Key Changes

### 2-1. Tooling

- **pnpm `11.5.1` → `11.5.2`** — Patch-level release of the package manager itself. A routine bug-fix bump with no breaking changes to the CLI, lockfile format, or resolution behavior. Reflected only in the documented/pinned version (`README.md` and the `package.json` description), not in the dependency graph.

### 2-2. Transitive dependencies (`pnpm-lock.yaml`)

- **electron-to-chromium `1.5.366` → `1.5.368`** — Auto-generated mapping of Electron releases to their bundled Chromium versions, consumed by `browserslist`/`caniuse`. Patch bumps only append newly published Electron→Chromium mappings; there is no runtime logic and nothing for callers to adapt to.
  - Integrity: `sha512-OlRuhb688YTCzzU3…` → `sha512-7RckJJK4uESJF9Px…`
- **semver `7.8.1` → `7.8.2`** — Patch release of the SemVer parsing/comparison library. Bug-fix only, fully backward compatible.

## 3. Summary

A minimal, low-risk lockfile refresh — the pinned pnpm version moves up one patch release, and only two data/utility transitive dependencies (`electron-to-chromium`, `semver`) move, both via patch-level releases.
No breaking changes and nothing for callers to adapt to.

## 4. References

- pnpm releases: [11.5.2 release notes](https://github.com/pnpm/pnpm/releases/tag/v11.5.2)
  - [Comparing changes between v11.5.1 and v11.5.2](https://github.com/pnpm/pnpm/compare/v11.5.1...v11.5.2)
- electron-to-chromium: [CHANGELOG.md](https://github.com/Kilian/electron-to-chromium/blob/master/CHANGELOG.md)
  - [Comparing changes between 1.5.366 and 1.5.368](https://github.com/Kilian/electron-to-chromium/compare/1.5.366...1.5.368)
- node-semver: [CHANGELOG.md](https://github.com/npm/node-semver/blob/main/CHANGELOG.md)
  - [Comparing changes between v7.8.1 and v7.8.2](https://github.com/npm/node-semver/compare/v7.8.1...v7.8.2)