### PR TITLE
[javascript] Update pnpm Package Dependencies

### DIFF
--- a/javascript/pnpm-lock.yaml
+++ b/javascript/pnpm-lock.yaml
@@ -1586,8 +1586,8 @@ packages:
   regjsgen@0.8.0:
     resolution: {integrity: sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==}
 
-  regjsparser@0.13.1:
-    resolution: {integrity: sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==}
+  regjsparser@0.13.2:
+    resolution: {integrity: sha512-NgRBy2Nx/bE+9F27nVHnqcN5HjyLmecqsqx2PJHu3/IEtADD4WuxuXIVExD5PoSDFVrl78dOonfcOe5O+5nbzQ==}
     hasBin: true
 
   require-directory@2.1.1:
@@ -3726,13 +3726,13 @@ snapshots:
       regenerate: 1.4.2
       regenerate-unicode-properties: 10.2.2
       regjsgen: 0.8.0
-      regjsparser: 0.13.1
+      regjsparser: 0.13.2
       unicode-match-property-ecmascript: 2.0.0
       unicode-match-property-value-ecmascript: 2.2.1
 
   regjsgen@0.8.0: {}
 
-  regjsparser@0.13.1:
+  regjsparser@0.13.2:
     dependencies:
       jsesc: 3.1.0
 


### PR DESCRIPTION
## 1. Overview

This PR (coding-tests #101) is a routine, dependabot-style bump of a single transitive pnpm dependency to its latest patch release.  
It touches the lockfile only — exactly **one file** (`javascript/pnpm-lock.yaml`) with **8 changed lines (4 additions / 4 deletions)** — with no `package.json` constraint changes and no pnpm version change.  
It is a very low-risk maintenance update.

## 2. Key Changes

- **regjsparser: 0.13.1 → 0.13.2** (in `javascript/pnpm-lock.yaml`)
  - A patch-level update of the regular-expression parser used internally by the Babel toolchain (pulled in transitively via `regexpu-core`, which `@babel/preset-env` depends on to transpile modern RegExp syntax).
  - The change appears in two places in the lockfile: the top-level `packages:` entry (resolution + integrity hash) and the `snapshots:` section where it is referenced by the Babel preset's dependency graph.
  - Integrity hash refreshed accordingly:
    - old: `sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==`
    - new: `sha512-NgRBy2Nx/bE+9F27nVHnqcN5HjyLmecqsqx2PJHu3/IEtADD4WuxuXIVExD5PoSDFVrl78dOonfcOe5O+5nbzQ==`
  - Being a `0.0.x` patch bump, it is a backward-compatible bug-fix release; there is no API surface change for consumers and no `package.json` constraint needed updating.

## 3. Summary

A patch-level lockfile refresh of a single build-time tooling dependency (`regjsparser`), pulled in transitively through Babel.  
The bump is backward-compatible, affects only `javascript/pnpm-lock.yaml`, and carries no behavioural risk to application code.

## 4. References

- [regjsparser](https://www.npmjs.com/package/regjsparse)
  - [GitHub repository](https://github.com/jviereck/regjsparser)
- [regexpu-core (consumer)](https://www.npmjs.com/package/regexpu-core)
- [@babel/preset-env (downstream consumer)](https://www.npmjs.com/package/@babel/preset-env)