### PR TITLE
[javascript] Bump pnpm from 11.5.2 to 11.7.0

### DIFF
--- a/javascript/README.md
+++ b/javascript/README.md
@@ -1,7 +1,7 @@
 ## 1. Environment
 
 - Node v26.3.0
-- pnpm 11.5.2
+- pnpm 11.7.0
 
 ## 2. JEST install for Unit Test
 

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coding-test-js",
   "version": "1.0.0",
-  "description": "* WSL(Ubuntu 25.10 (GNU/Linux 6.6.87.2-microsoft-standard-WSL2 x86_64)) * Node.js v26.3.0 * pnpm 11.5.2",
+  "description": "* WSL(Ubuntu 25.10 (GNU/Linux 6.6.87.2-microsoft-standard-WSL2 x86_64)) * Node.js v26.3.0 * pnpm 11.7.0",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
## 1. Overview

The differences between pnpm `11.5.2` and `11.7.0` are primarily found in `11.7.0`, which introduced several major features, performance enhancements, and fixes for monorepos, supply chain security, and environment setups.

## 2. Key New Features in `11.7.0` (relative to `11.5.2`)

- **`frozenStore` Setting**: Adds capability to lock installing dependencies against a read-only package store, which is ideal for CI environments or secure enterprise builds
- **`--batch` flag for publishing**: Allows users to publish an entire workspace of packages in a single request, speeding up monorepo publishing
- **Scope-Specific Auth Tokens**: Users can now safely restrict certain npm auth tokens to specific package scopes

## 3. Performance & Engine Improvements

- **Delegated Resolving Installs**: Full resolving installs are now delegated to pacquet, the Rust-backed resolution engine
- **Deterministic Install Paths**: Various installation paths were made deterministic to ensure consistent builds and reproducible outputs
- **Lockfile Updates**: Hardened the handling of lockfile aliases, resulting in safer and more stable workspace operations

## 4. Fixes & OS Adjustments

- Resolved a variety of **Windows-specific bugs**
- Several enhancements targeting improved **workspace publishing reliability**

## 5. What's else

If you're interested in making the jump, let me know:

- Is your project a monorepo / workspace?
- Are you running builds on Windows or in CI/CD pipelines?

I can provide specific instructions for a smooth update or show you how to configure features like `frozenStore`.

## 6. Reference

- [pnpm 11.7](https://pnpm.io/blog/releases/11.7)