### PR TITLE
[javascript] Update pnpm Package Dependencies

### DIFF
--- a/javascript/pnpm-lock.yaml
+++ b/javascript/pnpm-lock.yaml
@@ -1094,8 +1094,8 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
-  electron-to-chromium@1.5.372:
-    resolution: {integrity: sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==}
+  electron-to-chromium@1.5.375:
+    resolution: {integrity: sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q==}
 
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -3026,7 +3026,7 @@ snapshots:
     dependencies:
       baseline-browser-mapping: 2.10.37
       caniuse-lite: 1.0.30001799
-      electron-to-chromium: 1.5.372
+      electron-to-chromium: 1.5.375
       node-releases: 2.0.47
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
@@ -3097,7 +3097,7 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  electron-to-chromium@1.5.372: {}
+  electron-to-chromium@1.5.375: {}
 
   emittery@0.13.1: {}
 


### PR DESCRIPTION
## 1. Package change

| Package | Old version | New version |
| --- | --- | --- |
| electron-to-chromium | 1.5.372 | 1.5.375 |

Exact lines from `pnpm-lock.yaml`:

```diff
- electron-to-chromium@1.5.372:
+ electron-to-chromium@1.5.375:
...
- electron-to-chromium: 1.5.372
+ electron-to-chromium: 1.5.375
...
- electron-to-chromium@1.5.372: {}
+ electron-to-chromium@1.5.375: {}
```

The package's integrity hash was updated accordingly.

## 2. What changed

`electron-to-chromium` is a **data-only package**: it maps every Electron release to the Chromium version it ships, and is pulled in transitively as a dependency of **browserslist** (itself used by Babel, autoprefixer, and similar build tooling).  
It contains no runtime application code.

The bump from **1.5.372 → 1.5.375** is three automated patch releases that each add mapping data for newly published Electron/Chromium builds.  
There is **no API or behavior change** — only the lookup table grows.  
These releases are auto-published and not individually documented in the project changelog.

## 3. Risk / impact

- **Risk: very low.** Dev/build-time transitive dependency; data-only; patch-level (semver-compatible) bump.
- **Action:** safe to merge. Keeping it current improves the accuracy of `browserslist` target resolution for recent browsers.