### PR TITLE
[javascript] Update pnpm Package Dependencies

### DIFF
--- a/javascript/pnpm-lock.yaml
+++ b/javascript/pnpm-lock.yaml
@@ -1611,8 +1611,8 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.8.4:
-    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -3239,7 +3239,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@istanbuljs/schema': 0.1.6
       istanbul-lib-coverage: 3.2.2
-      semver: 7.8.4
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
@@ -3524,7 +3524,7 @@ snapshots:
       jest-message-util: 30.4.1
       jest-util: 30.4.1
       pretty-format: 30.4.1
-      semver: 7.8.4
+      semver: 7.8.5
       synckit: 0.11.13
     transitivePeerDependencies:
       - supports-color
@@ -3610,7 +3610,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.8.4
+      semver: 7.8.5
 
   makeerror@1.0.12:
     dependencies:
@@ -3753,7 +3753,7 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.8.4: {}
+  semver@7.8.5: {}
 
   shebang-command@2.0.0:
     dependencies:


### PR DESCRIPTION
## 1. Overview

This PR updates the pnpm package dependencies of the `javascript` project in the `coding-tests` repository.  
The change is a single patch-level bump of the transitive `semver` package, recorded in `javascript/pnpm-lock.yaml` (resolution integrity and the resolved version pinned across its dependents).  
No direct dependencies or application code are affected.

## 2. Key Changes & Differences in Each Package

|Packages |Before |After |Changes & Differences |
|:-|:-|:-|:-|
| semver | 7.8.4 | 7.8.5 | Bug fix: prereleases are now included in the tilde-range lower bound when `includePrerelease` is enabled (#878). |

## 3. Summary

A single transitive package, `semver`, was bumped from 7.8.4 to 7.8.5 — a patch release containing one prerelease range-matching bug fix.  
The update is low-risk and requires no code changes.

## 4. References

- [node-semver releases](https://github.com/npm/node-semver/releases)